### PR TITLE
Fix bad argument exception on termination

### DIFF
--- a/src/shackle_server.erl
+++ b/src/shackle_server.erl
@@ -271,6 +271,6 @@ terminate(Reason, #state {
 
     cancel_timer(TimerRef),
     ok = Client:terminate(ClientState),
-    ok = shackle_backlog:delete(Name),
     reply_all(Name, {error, shutdown}),
+    ok = shackle_backlog:delete(Name),
     exit(Reason).


### PR DESCRIPTION
`reply/3` wants to decrement the backlog, but we delete it before it can do that.  I think that either `shackle_backlog:decrement/1` should be aware of this possibility, or we should do the `delete/1` after sending replies.  I chose the latter option for simplicity.

I'd like to add a test for this but I wasn't sure about the best approach; I was thinking I could create a test client/server pair that have some extra commands to hold on to a request/response until the test signals it should go through.  This would allow more extensive testing of the backlog behavior.