### PR TITLE
Remove reply from cast()

### DIFF
--- a/include/shackle.hrl
+++ b/include/shackle.hrl
@@ -2,7 +2,6 @@
 -record(cast, {
     client         :: client(),
     pid            :: undefined | pid(),
-    reply          :: undefined | term(),
     request        :: term(),
     request_id     :: request_id(),
     timestamp      :: erlang:timestamp()

--- a/src/shackle.erl
+++ b/src/shackle.erl
@@ -69,7 +69,7 @@ receive_response(RequestId) ->
 
 receive_response(RequestId, Timeout) ->
     receive
-        #cast {request_id = RequestId, reply = Reply} ->
+        {#cast {request_id = RequestId}, Reply} ->
             Reply
     after Timeout ->
         shackle_queue:remove(RequestId),

--- a/src/shackle_server.erl
+++ b/src/shackle_server.erl
@@ -299,9 +299,7 @@ reply(Name, _Reply, #cast {pid = undefined}) ->
     shackle_backlog:decrement(Name);
 reply(Name, Reply, #cast {pid = Pid} = Cast) ->
     shackle_backlog:decrement(Name),
-    Pid ! Cast#cast {
-        reply = Reply
-    }.
+    Pid ! {Cast, Reply}.
 
 reply_all(Name, Reply) ->
     Requests = shackle_queue:clear(Name),


### PR DESCRIPTION
Remove `cast()` mutation from hot loop.