### PR TITLE
Fix default pool_strategy in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ shackle_pool:start(pool_name(), client(), client_options(), pool_options())
   <tr>
     <td>pool_strategy</td>
     <td>random | round_robin</td>
-    <td>round_robin</td>
+    <td>random</td>
     <td>connection selection strategy</td>
   </tr>
 </table>


### PR DESCRIPTION
I found that the value in the code is not the same as in README. Ofc it can be done the other way around(by changing README). 