### PR TITLE
Two choice random pool strategy

### DIFF
--- a/include/shackle.hrl
+++ b/include/shackle.hrl
@@ -44,8 +44,8 @@
 -type pool_options() :: [pool_option()].
 -type pool_options_rec() :: #pool_options {}.
 -type pool_size() :: pos_integer().
--type pool_strategy() :: random | round_robin.
--type protocol() :: shackle_ssl| shackle_tcp | shackle_udp.
+-type pool_strategy() :: random | round_robin | two_choice.
+-type protocol() :: shackle_ssl | shackle_tcp | shackle_udp.
 -type reconnect_state() :: #reconnect_state {}.
 -type request_id() :: {server_name(), reference()}.
 -type response() :: {external_request_id(), term()}.

--- a/src/shackle_backlog.erl
+++ b/src/shackle_backlog.erl
@@ -26,7 +26,7 @@ check(ServerName, BacklogSize) ->
     check(ServerName, BacklogSize, ?DEFAULT_INCREMENT).
 
 -spec check(server_name(), backlog_size(), pos_integer()) ->
-    boolean().
+    pos_integer() | false.
 
 check(_ServerName, infinity, _Increment) ->
     true;
@@ -35,7 +35,7 @@ check(ServerName, BacklogSize, Increment) ->
         [BacklogSize, BacklogSize] ->
             false;
         [_, Value] when Value =< BacklogSize ->
-            true
+            Value
     end.
 
 -spec decrement(server_name()) ->

--- a/src/shackle_backlog.erl
+++ b/src/shackle_backlog.erl
@@ -11,6 +11,8 @@
     decrement/1,
     decrement/2,
     delete/1,
+    increment/2,
+    increment/3,
     init/0,
     new/1
 ]).
@@ -26,7 +28,7 @@ check(ServerName, BacklogSize) ->
     check(ServerName, BacklogSize, ?DEFAULT_INCREMENT).
 
 -spec check(server_name(), backlog_size(), pos_integer()) ->
-    pos_integer() | false.
+    boolean().
 
 check(_ServerName, infinity, _Increment) ->
     true;
@@ -35,7 +37,7 @@ check(ServerName, BacklogSize, Increment) ->
         [BacklogSize, BacklogSize] ->
             false;
         [_, Value] when Value =< BacklogSize ->
-            Value
+            true
     end.
 
 -spec decrement(server_name()) ->
@@ -57,6 +59,19 @@ delete(ServerName) ->
     ets:delete(?ETS_TABLE_BACKLOG, ServerName),
     ok.
 
+-spec increment(server_name(), backlog_size()) ->
+    list(pos_integer()).
+
+increment(ServerName, BacklogSize) ->
+    increment(ServerName, BacklogSize, ?DEFAULT_INCREMENT).
+
+-spec increment(server_name(), backlog_size(), pos_integer()) ->
+    list(pos_integer()).
+
+increment(ServerName, BacklogSize, Increment) ->
+    UpdateOps = [{2, 0}, {2, Increment, BacklogSize, BacklogSize}],
+    ets:update_counter(?ETS_TABLE_BACKLOG, ServerName, UpdateOps).
+
 -spec init() ->
     ok.
 
@@ -74,8 +89,3 @@ init() ->
 new(ServerName) ->
     ets:insert(?ETS_TABLE_BACKLOG, {ServerName, 0}),
     ok.
-
-%% private
-increment(ServerName, BacklogSize, Increment) ->
-    UpdateOps = [{2, 0}, {2, Increment, BacklogSize, BacklogSize}],
-    ets:update_counter(?ETS_TABLE_BACKLOG, ServerName, UpdateOps).

--- a/src/shackle_pool.erl
+++ b/src/shackle_pool.erl
@@ -95,8 +95,8 @@ server(Name) ->
                 false ->
                     {error, backlog_full}
             end;
-        {error, Reson} ->
-            {error, Reson}
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 %% private

--- a/src/shackle_pool.erl
+++ b/src/shackle_pool.erl
@@ -108,8 +108,10 @@ choose_server(Name,
         {false, false} ->
             {error, backlog_full};
         {A, B} when B =:= false orelse A =< B ->
+            shackle_backlog:decrement(ServerB),
             {ok, Client, ServerA};
         {_, _} ->
+            shackle_backlog:decrement(ServerA),
             {ok, Client, ServerB}
     end;
 

--- a/test/shackle_tests.erl
+++ b/test/shackle_tests.erl
@@ -130,6 +130,28 @@ shackle_round_robin_udp_test_() ->
         fun multiply_udp_subtest/0
     ]}}.
 
+shackle_two_choice_tcp_test_() ->
+    {setup,
+        fun () -> setup_tcp([
+            {pool_strategy, two_choice}
+        ]) end,
+        fun (_) -> cleanup_tcp() end,
+    {inparallel, [
+        fun add_tcp_subtest/0,
+        fun multiply_tcp_subtest/0
+    ]}}.
+
+shackle_two_choice_udp_test_() ->
+    {setup,
+        fun () -> setup_udp([
+            {pool_strategy, two_choice}
+        ]) end,
+        fun (_) -> cleanup_udp() end,
+    {inparallel, [
+        fun add_udp_subtest/0,
+        fun multiply_udp_subtest/0
+    ]}}.
+
 %% tests
 add_ssl_subtest() ->
     [assert_random_add(?CLIENT_SSL) || _ <- lists:seq(1, ?N)].


### PR DESCRIPTION
This adds a pool strategy that does two-choice randomized load balancing, as per this [paper](https://www.eecs.harvard.edu/~michaelm/postscripts/mythesis.pdf). I haven't benchmarked this, but the theoretical bounds are extremely promising, as does the benchmark carried out [here](https://brooker.co.za/blog/2012/01/17/two-random.html).

The other two commits fix a typo in a variable name and (what I believe to be) an erroneous spec.