### PR TITLE
Fix setup error socket leak

### DIFF
--- a/src/shackle_server.erl
+++ b/src/shackle_server.erl
@@ -136,7 +136,7 @@ handle_msg(?MSG_CONNECT, #state {
                         {error, Reason, ClientState3} ->
                             shackle_utils:warning_msg(PoolName,
                                 "setup error: ~p", [Reason]),
-
+                            Protocol:close(Socket),
                             reconnect(State, ClientState3)
                     end;
                 {error, Reason} ->


### PR DESCRIPTION
This PR fixes a leak that happens when the setup callback returns an error.