### PR TITLE
Changes Client:init() to accept a term as client initialization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ High Performance Erlang Network Client Framework
     request_counter = 0 :: non_neg_integer()
 }).
 
--spec init() -> {ok, State :: term()}.
+-spec init(Options :: term()) -> {ok, State :: term()}.
 
-init() ->
+init(_) ->
      {ok, #state {}}.
 
 -spec setup(Socket :: inet:socket(), State :: term()) ->
@@ -155,6 +155,12 @@ shackle_pool:start(pool_name(), client(), client_options(), pool_options())
     <td>[gen_tcp:connect_option() | gen_udp:option()]</td>
     <td>[]</td>
     <td>options passed to the socket</td>
+  </tr>
+  <tr>
+    <td>init_options</td>
+    <td>term()</td>
+    <td>undefined</td>
+    <td>options passed to client module when init is called</td>
   </tr>
 </table>
 

--- a/doc/shackle.md
+++ b/doc/shackle.md
@@ -22,6 +22,16 @@ backlog_size() = pos_integer() | infinity
 
 
 
+### <a name="type-client_init_options">client_init_options()</a> ###
+
+
+<pre><code>
+client_init_options() = term()
+</code></pre>
+
+
+
+
 ### <a name="type-client_option">client_option()</a> ###
 
 

--- a/doc/shackle_app.md
+++ b/doc/shackle_app.md
@@ -24,6 +24,16 @@ backlog_size() = pos_integer() | infinity
 
 
 
+### <a name="type-client_init_options">client_init_options()</a> ###
+
+
+<pre><code>
+client_init_options() = term()
+</code></pre>
+
+
+
+
 ### <a name="type-client_option">client_option()</a> ###
 
 

--- a/doc/shackle_backlog.md
+++ b/doc/shackle_backlog.md
@@ -22,6 +22,16 @@ backlog_size() = pos_integer() | infinity
 
 
 
+### <a name="type-client_init_options">client_init_options()</a> ###
+
+
+<pre><code>
+client_init_options() = term()
+</code></pre>
+
+
+
+
 ### <a name="type-client_option">client_option()</a> ###
 
 

--- a/doc/shackle_backoff.md
+++ b/doc/shackle_backoff.md
@@ -22,6 +22,16 @@ backlog_size() = pos_integer() | infinity
 
 
 
+### <a name="type-client_init_options">client_init_options()</a> ###
+
+
+<pre><code>
+client_init_options() = term()
+</code></pre>
+
+
+
+
 ### <a name="type-client_option">client_option()</a> ###
 
 

--- a/doc/shackle_client.md
+++ b/doc/shackle_client.md
@@ -3,7 +3,7 @@
 # Module shackle_client #
 * [Data Types](#types)
 
-__This module defines the `shackle_client` behaviour.__<br /> Required callback functions: `init/0`, `setup/2`, `handle_request/2`, `handle_data/2`, `terminate/1`.
+__This module defines the `shackle_client` behaviour.__<br /> Required callback functions: `init/1`, `setup/2`, `handle_request/2`, `handle_data/2`, `terminate/1`.
 
 <a name="types"></a>
 
@@ -17,6 +17,16 @@ __This module defines the `shackle_client` behaviour.__<br /> Required callback 
 
 <pre><code>
 backlog_size() = pos_integer() | infinity
+</code></pre>
+
+
+
+
+### <a name="type-client_init_options">client_init_options()</a> ###
+
+
+<pre><code>
+client_init_options() = term()
 </code></pre>
 
 

--- a/doc/shackle_compiler.md
+++ b/doc/shackle_compiler.md
@@ -32,6 +32,16 @@ client() = module()
 
 
 
+### <a name="type-client_init_options">client_init_options()</a> ###
+
+
+<pre><code>
+client_init_options() = term()
+</code></pre>
+
+
+
+
 ### <a name="type-client_option">client_option()</a> ###
 
 

--- a/doc/shackle_pool.md
+++ b/doc/shackle_pool.md
@@ -32,6 +32,16 @@ client() = module()
 
 
 
+### <a name="type-client_init_options">client_init_options()</a> ###
+
+
+<pre><code>
+client_init_options() = term()
+</code></pre>
+
+
+
+
 ### <a name="type-client_option">client_option()</a> ###
 
 

--- a/doc/shackle_queue.md
+++ b/doc/shackle_queue.md
@@ -42,6 +42,16 @@ client() = module()
 
 
 
+### <a name="type-client_init_options">client_init_options()</a> ###
+
+
+<pre><code>
+client_init_options() = term()
+</code></pre>
+
+
+
+
 ### <a name="type-client_option">client_option()</a> ###
 
 

--- a/doc/shackle_ssl_server.md
+++ b/doc/shackle_ssl_server.md
@@ -32,6 +32,16 @@ client() = module()
 
 
 
+### <a name="type-client_init_options">client_init_options()</a> ###
+
+
+<pre><code>
+client_init_options() = term()
+</code></pre>
+
+
+
+
 ### <a name="type-client_option">client_option()</a> ###
 
 
@@ -156,7 +166,7 @@ server_name() = atom()
 
 
 <pre><code>
-state() = #state{client = <a href="#type-client">client()</a>, ip = <a href="inet.md#type-ip_address">inet:ip_address()</a> | <a href="inet.md#type-hostname">inet:hostname()</a>, name = <a href="#type-server_name">server_name()</a>, parent = pid(), pool_name = <a href="#type-pool_name">pool_name()</a>, port = <a href="inet.md#type-port_number">inet:port_number()</a>, reconnect_state = undefined | <a href="#type-reconnect_state">reconnect_state()</a>, socket = undefined | <a href="inet.md#type-socket">inet:socket()</a>, socket_options = [<a href="ssl.md#type-connect_option">ssl:connect_option()</a>], timer_ref = undefined | reference()}
+state() = #state{client = <a href="#type-client">client()</a>, ip = <a href="inet.md#type-ip_address">inet:ip_address()</a> | <a href="inet.md#type-hostname">inet:hostname()</a>, name = <a href="#type-server_name">server_name()</a>, parent = pid(), pool_name = <a href="#type-pool_name">pool_name()</a>, port = <a href="inet.md#type-port_number">inet:port_number()</a>, reconnect_state = undefined | <a href="#type-reconnect_state">reconnect_state()</a>, socket = undefined | <a href="inet.md#type-socket">inet:socket()</a>, socket_options = [<a href="ssl.md#type-connect_option">ssl:connect_option()</a>], init_options = [<a href="#type-client_init_options">client_init_options()</a>], timer_ref = undefined | reference()}
 </code></pre>
 
 

--- a/doc/shackle_sup.md
+++ b/doc/shackle_sup.md
@@ -24,6 +24,16 @@ backlog_size() = pos_integer() | infinity
 
 
 
+### <a name="type-client_init_options">client_init_options()</a> ###
+
+
+<pre><code>
+client_init_options() = term()
+</code></pre>
+
+
+
+
 ### <a name="type-client_option">client_option()</a> ###
 
 

--- a/doc/shackle_tcp_server.md
+++ b/doc/shackle_tcp_server.md
@@ -32,6 +32,16 @@ client() = module()
 
 
 
+### <a name="type-client_init_options">client_init_options()</a> ###
+
+
+<pre><code>
+client_init_options() = term()
+</code></pre>
+
+
+
+
 ### <a name="type-client_option">client_option()</a> ###
 
 
@@ -156,7 +166,7 @@ server_name() = atom()
 
 
 <pre><code>
-state() = #state{client = <a href="#type-client">client()</a>, ip = <a href="inet.md#type-ip_address">inet:ip_address()</a> | <a href="inet.md#type-hostname">inet:hostname()</a>, name = <a href="#type-server_name">server_name()</a>, parent = pid(), pool_name = <a href="#type-pool_name">pool_name()</a>, port = <a href="inet.md#type-port_number">inet:port_number()</a>, reconnect_state = undefined | <a href="#type-reconnect_state">reconnect_state()</a>, socket = undefined | <a href="inet.md#type-socket">inet:socket()</a>, socket_options = [<a href="gen_tcp.md#type-connect_option">gen_tcp:connect_option()</a>], timer_ref = undefined | reference()}
+state() = #state{client = <a href="#type-client">client()</a>, ip = <a href="inet.md#type-ip_address">inet:ip_address()</a> | <a href="inet.md#type-hostname">inet:hostname()</a>, name = <a href="#type-server_name">server_name()</a>, parent = pid(), pool_name = <a href="#type-pool_name">pool_name()</a>, port = <a href="inet.md#type-port_number">inet:port_number()</a>, reconnect_state = undefined | <a href="#type-reconnect_state">reconnect_state()</a>, socket = undefined | <a href="inet.md#type-socket">inet:socket()</a>, socket_options = [<a href="gen_tcp.md#type-connect_option">gen_tcp:connect_option()</a>], init_options = <a href="#type-client_init_options">client_init_options()</a>, timer_ref = undefined | reference()}
 </code></pre>
 
 

--- a/doc/shackle_udp_server.md
+++ b/doc/shackle_udp_server.md
@@ -32,6 +32,16 @@ client() = module()
 
 
 
+### <a name="type-client_init_options">client_init_options()</a> ###
+
+
+<pre><code>
+client_init_options() = term()
+</code></pre>
+
+
+
+
 ### <a name="type-client_option">client_option()</a> ###
 
 
@@ -156,7 +166,7 @@ server_name() = atom()
 
 
 <pre><code>
-state() = #state{client = <a href="#type-client">client()</a>, header = undefined | iodata(), ip = <a href="inet.md#type-ip_address">inet:ip_address()</a> | <a href="inet.md#type-hostname">inet:hostname()</a>, name = <a href="#type-server_name">server_name()</a>, parent = pid(), pool_name = <a href="#type-pool_name">pool_name()</a>, port = <a href="inet.md#type-port_number">inet:port_number()</a>, reconnect_state = undefined | <a href="#type-reconnect_state">reconnect_state()</a>, socket = undefined | <a href="inet.md#type-socket">inet:socket()</a>, socket_options = [<a href="gen_udp.md#type-option">gen_udp:option()</a>], timer_ref = undefined | reference()}
+state() = #state{client = <a href="#type-client">client()</a>, header = undefined | iodata(), ip = <a href="inet.md#type-ip_address">inet:ip_address()</a> | <a href="inet.md#type-hostname">inet:hostname()</a>, name = <a href="#type-server_name">server_name()</a>, parent = pid(), pool_name = <a href="#type-pool_name">pool_name()</a>, port = <a href="inet.md#type-port_number">inet:port_number()</a>, reconnect_state = undefined | <a href="#type-reconnect_state">reconnect_state()</a>, socket = undefined | <a href="inet.md#type-socket">inet:socket()</a>, socket_options = [<a href="gen_udp.md#type-option">gen_udp:option()</a>], init_options = [<a href="#type-client_init_options">client_init_options()</a>], timer_ref = undefined | reference()}
 </code></pre>
 
 

--- a/doc/shackle_utils.md
+++ b/doc/shackle_utils.md
@@ -42,6 +42,16 @@ client() = module()
 
 
 
+### <a name="type-client_init_options">client_init_options()</a> ###
+
+
+<pre><code>
+client_init_options() = term()
+</code></pre>
+
+
+
+
 ### <a name="type-client_option">client_option()</a> ###
 
 
@@ -194,7 +204,7 @@ time() = pos_integer()
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#cancel_timer-1">cancel_timer/1</a></td><td></td></tr><tr><td valign="top"><a href="#client_setup-3">client_setup/3</a></td><td></td></tr><tr><td valign="top"><a href="#lookup-3">lookup/3</a></td><td></td></tr><tr><td valign="top"><a href="#process_responses-2">process_responses/2</a></td><td></td></tr><tr><td valign="top"><a href="#random-1">random/1</a></td><td></td></tr><tr><td valign="top"><a href="#random_element-1">random_element/1</a></td><td></td></tr><tr><td valign="top"><a href="#reconnect_state-1">reconnect_state/1</a></td><td></td></tr><tr><td valign="top"><a href="#reconnect_state_reset-1">reconnect_state_reset/1</a></td><td></td></tr><tr><td valign="top"><a href="#reply-3">reply/3</a></td><td></td></tr><tr><td valign="top"><a href="#reply_all-2">reply_all/2</a></td><td></td></tr><tr><td valign="top"><a href="#warning_msg-3">warning_msg/3</a></td><td></td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#cancel_timer-1">cancel_timer/1</a></td><td></td></tr><tr><td valign="top"><a href="#client_setup-4">client_setup/4</a></td><td></td></tr><tr><td valign="top"><a href="#lookup-3">lookup/3</a></td><td></td></tr><tr><td valign="top"><a href="#process_responses-2">process_responses/2</a></td><td></td></tr><tr><td valign="top"><a href="#random-1">random/1</a></td><td></td></tr><tr><td valign="top"><a href="#random_element-1">random_element/1</a></td><td></td></tr><tr><td valign="top"><a href="#reconnect_state-1">reconnect_state/1</a></td><td></td></tr><tr><td valign="top"><a href="#reconnect_state_reset-1">reconnect_state_reset/1</a></td><td></td></tr><tr><td valign="top"><a href="#reply-3">reply/3</a></td><td></td></tr><tr><td valign="top"><a href="#reply_all-2">reply_all/2</a></td><td></td></tr><tr><td valign="top"><a href="#warning_msg-3">warning_msg/3</a></td><td></td></tr></table>
 
 
 <a name="functions"></a>
@@ -210,12 +220,12 @@ cancel_timer(TimerRef::undefined | reference()) -&gt; ok
 </code></pre>
 <br />
 
-<a name="client_setup-3"></a>
+<a name="client_setup-4"></a>
 
-### client_setup/3 ###
+### client_setup/4 ###
 
 <pre><code>
-client_setup(Client::<a href="#type-client">client()</a>, PoolName::<a href="#type-pool_name">pool_name()</a>, Socket::<a href="inet.md#type-socket">inet:socket()</a>) -&gt; {ok, <a href="#type-client_state">client_state()</a>} | {error, term(), <a href="#type-client_state">client_state()</a>}
+client_setup(Client::<a href="#type-client">client()</a>, PoolName::<a href="#type-pool_name">pool_name()</a>, Socket::<a href="inet.md#type-socket">inet:socket()</a>, ClientInitOptions::<a href="#type-client_init_options">client_init_options()</a>) -&gt; {ok, <a href="#type-client_state">client_state()</a>} | {error, term(), <a href="#type-client_state">client_state()</a>}
 </code></pre>
 <br />
 

--- a/include/shackle.hrl
+++ b/include/shackle.hrl
@@ -52,7 +52,10 @@
 -type server_name() :: atom().
 -type time() :: pos_integer().
 
+-type client_init_options() :: term().
+
 -export_type([
     client_options/0,
+    client_init_options/0,
     pool_options/0
 ]).

--- a/include/shackle_defaults.hrl
+++ b/include/shackle_defaults.hrl
@@ -9,4 +9,5 @@
 -define(DEFAULT_RECONNECT_MAX, timer:minutes(2)).
 -define(DEFAULT_RECONNECT_MIN, 500).
 -define(DEFAULT_SOCKET_OPTS, []).
+-define(DEFAULT_CLIENT_INIT_OPTS, undefined).
 -define(DEFAULT_TIMEOUT, 1000).

--- a/src/shackle_client.erl
+++ b/src/shackle_client.erl
@@ -1,7 +1,7 @@
 -module(shackle_client).
 -include("shackle_internal.hrl").
 
--callback init() ->
+-callback init(Options :: term()) ->
     {ok, State :: term()}.
 
 -callback setup(Socket :: inet:socket(), State :: term()) ->

--- a/src/shackle_ssl_server.erl
+++ b/src/shackle_ssl_server.erl
@@ -21,6 +21,7 @@
     reconnect_state  :: undefined | reconnect_state(),
     socket           :: undefined | inet:socket(),
     socket_options   :: [ssl:connect_option()],
+    init_options     :: [client_init_options()],
     timer_ref        :: undefined | reference()
 }).
 
@@ -48,6 +49,8 @@ init(Name, Parent, Opts) ->
     ReconnectState = shackle_utils:reconnect_state(ClientOptions),
     SocketOptions = ?LOOKUP(socket_options, ClientOptions,
         ?DEFAULT_SOCKET_OPTS),
+    ClientInitOptions = ?LOOKUP(init_options, ClientOptions,
+        ?DEFAULT_CLIENT_INIT_OPTS),
 
     {ok, {#state {
         client = Client,
@@ -57,7 +60,8 @@ init(Name, Parent, Opts) ->
         pool_name = PoolName,
         port = Port,
         reconnect_state = ReconnectState,
-        socket_options = SocketOptions
+        socket_options = SocketOptions,
+        init_options = ClientInitOptions
     }, undefined}}.
 
 -spec handle_msg(term(), {state(), client_state()}) ->
@@ -142,12 +146,14 @@ handle_msg(?MSG_CONNECT, {#state {
         pool_name = PoolName,
         port = Port,
         reconnect_state = ReconnectState,
-        socket_options = SocketOptions
+        socket_options = SocketOptions,
+        init_options = ClientInitOptions
     } = State, ClientState}) ->
 
     case connect(PoolName, Ip, Port, SocketOptions) of
         {ok, Socket} ->
-            case client_setup(Client, PoolName, Socket) of
+            case client_setup(Client, PoolName, Socket,
+                ClientInitOptions) of
                 {ok, ClientState2} ->
                     ReconnectState2 =
                         shackle_utils:reconnect_state_reset(ReconnectState),
@@ -180,8 +186,8 @@ terminate(_Reason, {#state {
     ok.
 
 %% private
-client_setup(Client, PoolName, Socket) ->
-    {ok, ClientState} = Client:init(),
+client_setup(Client, PoolName, Socket, ClientInitOptions) ->
+    {ok, ClientState} = Client:init(ClientInitOptions),
     ssl:setopts(Socket, [{active, false}]),
     case Client:setup(Socket, ClientState) of
         {ok, ClientState2} ->

--- a/src/shackle_tcp_server.erl
+++ b/src/shackle_tcp_server.erl
@@ -21,6 +21,7 @@
     reconnect_state  :: undefined | reconnect_state(),
     socket           :: undefined | inet:socket(),
     socket_options   :: [gen_tcp:connect_option()],
+    init_options     :: client_init_options(),
     timer_ref        :: undefined | reference()
 }).
 
@@ -48,6 +49,8 @@ init(Name, Parent, Opts) ->
     ReconnectState = shackle_utils:reconnect_state(ClientOptions),
     SocketOptions = ?LOOKUP(socket_options, ClientOptions,
         ?DEFAULT_SOCKET_OPTS),
+    ClientInitOptions = ?LOOKUP(init_options, ClientOptions,
+        ?DEFAULT_CLIENT_INIT_OPTS),
 
     {ok, {#state {
         client = Client,
@@ -57,7 +60,8 @@ init(Name, Parent, Opts) ->
         pool_name = PoolName,
         port = Port,
         reconnect_state = ReconnectState,
-        socket_options = SocketOptions
+        socket_options = SocketOptions,
+        init_options = ClientInitOptions
     }, undefined}}.
 
 -spec handle_msg(term(), {state(), client_state()}) ->
@@ -142,12 +146,14 @@ handle_msg(?MSG_CONNECT, {#state {
         pool_name = PoolName,
         port = Port,
         reconnect_state = ReconnectState,
-        socket_options = SocketOptions
+        socket_options = SocketOptions,
+        init_options = ClientInitOptions
     } = State, ClientState}) ->
 
     case connect(PoolName, Ip, Port, SocketOptions) of
         {ok, Socket} ->
-            case shackle_utils:client_setup(Client, PoolName, Socket) of
+            case shackle_utils:client_setup(Client, PoolName, Socket,
+                ClientInitOptions) of
                 {ok, ClientState2} ->
                     ReconnectState2 =
                         shackle_utils:reconnect_state_reset(ReconnectState),

--- a/src/shackle_udp_server.erl
+++ b/src/shackle_udp_server.erl
@@ -22,6 +22,7 @@
     reconnect_state  :: undefined | reconnect_state(),
     socket           :: undefined | inet:socket(),
     socket_options   :: [gen_udp:option()],
+    init_options     :: [client_init_options()],
     timer_ref        :: undefined | reference()
 }).
 
@@ -52,6 +53,8 @@ init(Name, Parent, Opts) ->
     ReconnectState = shackle_utils:reconnect_state(ClientOptions),
     SocketOptions = ?LOOKUP(socket_options, ClientOptions,
         ?DEFAULT_SOCKET_OPTS),
+    ClientInitOptions = ?LOOKUP(init_options, ClientOptions,
+        ?DEFAULT_CLIENT_INIT_OPTS),
 
     {ok, {#state {
         client = Client,
@@ -61,7 +64,8 @@ init(Name, Parent, Opts) ->
         pool_name = PoolName,
         port = Port,
         reconnect_state = ReconnectState,
-        socket_options = SocketOptions
+        socket_options = SocketOptions,
+        init_options = ClientInitOptions
     }, undefined}}.
 
 -spec handle_msg(term(), {state(), client_state()}) ->
@@ -140,12 +144,14 @@ handle_msg(?MSG_CONNECT, {#state {
         pool_name = PoolName,
         port = Port,
         reconnect_state = ReconnectState,
-        socket_options = SocketOptions
+        socket_options = SocketOptions,
+        init_options = ClientInitOptions
     } = State, ClientState}) ->
 
     case connect(PoolName, Ip, Port, SocketOptions) of
         {ok, Header, Socket} ->
-            case shackle_utils:client_setup(Client, PoolName, Socket) of
+            case shackle_utils:client_setup(Client, PoolName, Socket,
+                ClientInitOptions) of
                 {ok, ClientState2} ->
                     ReconnectState2 =
                         shackle_utils:reconnect_state_reset(ReconnectState),

--- a/src/shackle_utils.erl
+++ b/src/shackle_utils.erl
@@ -7,7 +7,7 @@
 %% public
 -export([
     cancel_timer/1,
-    client_setup/3,
+    client_setup/4,
     lookup/3,
     process_responses/2,
     random/1,
@@ -28,11 +28,14 @@ cancel_timer(undefined) ->
 cancel_timer(TimerRef) ->
     erlang:cancel_timer(TimerRef).
 
--spec client_setup(client(), pool_name(), inet:socket()) ->
+-spec client_setup(client(),
+                   pool_name(),
+                   inet:socket(),
+                   client_init_options()) ->
     {ok, client_state()} | {error, term(), client_state()}.
 
-client_setup(Client, PoolName, Socket) ->
-    {ok, ClientState} = Client:init(),
+client_setup(Client, PoolName, Socket, ClientInitOptions) ->
+    {ok, ClientState} = Client:init(ClientInitOptions),
     inet:setopts(Socket, [{active, false}]),
     case Client:setup(Socket, ClientState) of
         {ok, ClientState2} ->

--- a/test/arithmetic_ssl_client.erl
+++ b/test/arithmetic_ssl_client.erl
@@ -11,7 +11,7 @@
 
 -behavior(shackle_client).
 -export([
-    init/0,
+    init/1,
     setup/2,
     handle_request/2,
     handle_data/2,
@@ -68,7 +68,7 @@ stop() ->
     shackle_pool:stop(?POOL_NAME).
 
 %% shackle_server callbacks
-init() ->
+init(_) ->
     {ok, #state {}}.
 
 setup(Socket, State) ->

--- a/test/arithmetic_tcp_client.erl
+++ b/test/arithmetic_tcp_client.erl
@@ -11,7 +11,7 @@
 
 -behavior(shackle_client).
 -export([
-    init/0,
+    init/1,
     setup/2,
     handle_request/2,
     handle_data/2,
@@ -67,7 +67,7 @@ stop() ->
     shackle_pool:stop(?POOL_NAME).
 
 %% shackle_server callbacks
-init() ->
+init(_) ->
     {ok, #state {}}.
 
 setup(Socket, State) ->

--- a/test/arithmetic_udp_client.erl
+++ b/test/arithmetic_udp_client.erl
@@ -11,7 +11,7 @@
 
 -behavior(shackle_client).
 -export([
-    init/0,
+    init/1,
     setup/2,
     handle_request/2,
     handle_data/2,
@@ -67,7 +67,7 @@ stop() ->
     shackle_pool:stop(?POOL_NAME).
 
 %% shackle_server callbacks
-init() ->
+init(_) ->
     {ok, #state {}}.
 
 setup(Socket, State) ->


### PR DESCRIPTION
### WHAT
There are some cases where the setup phase of the client needs to know the initial options. For example connecting to a database and doing some sort of authentication. For a better, real-world example, consider Redis where an `AUTH` command has to be sent after a connection has been established. 

This PR adds this feature. 

### Implementation details
The client options for starting the pool will accept a proplist as `setup_options`. This will be stored in the "protocol_server" and passed to the client setup function.

### Concerns
This will break backwards compatibility and updating to a new version will be annoying. However, I don't think there is too much overhead for people to add a third function argument to their client modules.