### PR TITLE
_build dir not use cache in different versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ addons:
 cache:
   directories:
     - $HOME/.cache/rebar3
-    - $TRAVIS_BUILD_DIR/_build
 env:
   - CC=gcc-5
 install: true


### PR DESCRIPTION
The `_build` dir needs to download the source files, and compile them from stractch. If use cache, the beam file will not compile again. Disable it.