### PR TITLE
Fix bad_match when socket is already closed

### DIFF
--- a/src/shackle_ssl_server.erl
+++ b/src/shackle_ssl_server.erl
@@ -95,7 +95,7 @@ handle_msg(#cast {
             shackle_utils:reply(Name, {error, socket_closed}, Cast),
             close(State, ClientState2)
     end;
-handle_msg({ssl, _Socket, Data}, {#state {
+handle_msg({ssl, Socket, Data}, {#state {
         client = Client,
         name = Name,
         pool_name = PoolName,
@@ -164,7 +164,13 @@ handle_msg(?MSG_CONNECT, {#state {
             end;
         {error, _Reason} ->
             reconnect(State, ClientState)
-    end.
+    end;
+handle_msg(Msg, {#state {
+        pool_name = PoolName
+    } = State, ClientState}) ->
+
+    shackle_utils:warning_msg(PoolName, "unknown msg: ~p", [Msg]),
+    {ok, {State, ClientState}}.
 
 -spec terminate(term(), term()) ->
     ok.

--- a/src/shackle_tcp_server.erl
+++ b/src/shackle_tcp_server.erl
@@ -95,7 +95,7 @@ handle_msg(#cast {
             shackle_utils:reply(Name, {error, socket_closed}, Cast),
             close(State, ClientState2)
     end;
-handle_msg({tcp, _Socket, Data}, {#state {
+handle_msg({tcp, Socket, Data}, {#state {
         client = Client,
         name = Name,
         pool_name = PoolName,
@@ -164,7 +164,13 @@ handle_msg(?MSG_CONNECT, {#state {
             end;
         {error, _Reason} ->
             reconnect(State, ClientState)
-    end.
+    end;
+handle_msg(Msg, {#state {
+        pool_name = PoolName
+    } = State, ClientState}) ->
+
+    shackle_utils:warning_msg(PoolName, "unknown msg: ~p", [Msg]),
+    {ok, {State, ClientState}}.
 
 -spec terminate(term(), term()) ->
     ok.

--- a/src/shackle_udp_server.erl
+++ b/src/shackle_udp_server.erl
@@ -102,7 +102,7 @@ handle_msg(#cast {
     end;
 handle_msg({inet_reply, _Socket, ok}, {State, ClientState}) ->
     {ok, {State, ClientState}};
-handle_msg({udp, _Socket, _Ip, _InPortNo, Data}, {#state {
+handle_msg({udp, Socket, _Ip, _InPortNo, Data}, {#state {
         client = Client,
         name = Name,
         pool_name = PoolName,
@@ -130,8 +130,9 @@ handle_msg({timeout, ExtRequestId}, {#state {
             ok
     end,
     {ok, {State, ClientState}};
-handle_msg({inet_reply, _Socket, {error, Reason}}, {#state {
-        pool_name = PoolName
+handle_msg({inet_reply, Socket, {error, Reason}}, {#state {
+        pool_name = PoolName,
+        socket = Socket
     } = State, ClientState}) ->
 
     shackle_utils:warning_msg(PoolName, "send error: ~p", [Reason]),
@@ -163,7 +164,13 @@ handle_msg(?MSG_CONNECT, {#state {
             end;
         {error, _Reason} ->
             reconnect(State, ClientState)
-    end.
+    end;
+handle_msg(Msg, {#state {
+        pool_name = PoolName
+    } = State, ClientState}) ->
+
+    shackle_utils:warning_msg(PoolName, "unknown msg: ~p", [Msg]),
+    {ok, {State, ClientState}}.
 
 -spec terminate(term(), term()) ->
     ok.


### PR DESCRIPTION
```
2017-11-07 15:21:14.000 [err] <0.30.0>@rtb-gateway.localhost <sasl> {<0.12488.3939>,crash_report,
 [[{initial_call,
       {metal,init,['Argument__1','Argument__2','Argument__3','Argument__4']}},
   {pid,<0.12488.3939>},
   {registered_name,'http_72.251.245.178_8080_4'},
   {error_info,
       {error,function_clause,
           [{inet,tcp_close,[undefined],[{file,"inet.erl"},{line,1618}]},
            {shackle_tcp_server,handle_msg,2,
                [{file,
                     "/var/tmp/portage/bloom/rtb-gateway-1.33.1/work/rtb-gateway-1.33.1/_build/default/lib/shackle/src/shackle_tcp_server.erl"},
                 {line,118}]},
            {metal,loop,4,
                [{file,
                     "/var/tmp/portage/bloom/rtb-gateway-1.33.1/work/rtb-gateway-1.33.1/_build/default/lib/metal/src/metal.erl"},
                 {line,88}]},
            {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]}},
   {ancestors,[shackle_sup,<0.111.0>]},
   {messages,[]},
   {links,[<0.112.0>]},
   {dictionary,[]},
   {trap_exit,true},
   {status,running},
   {heap_size,46422},
   {stack_size,27},
   {reductions,91253530}],
  []]}
```