### PR TITLE
delete foil namespace for shackle_pool on stop

### DIFF
--- a/src/shackle_app.erl
+++ b/src/shackle_app.erl
@@ -37,5 +37,5 @@ start(_StartType, _StartArgs) ->
     ok.
 
 stop(_State) ->
-    shackle_pool:stop(),
+    shackle_pool:terminate(),
     ok.

--- a/src/shackle_app.erl
+++ b/src/shackle_app.erl
@@ -37,4 +37,5 @@ start(_StartType, _StartArgs) ->
     ok.
 
 stop(_State) ->
+    shackle_pool:stop(),
     ok.

--- a/src/shackle_pool.erl
+++ b/src/shackle_pool.erl
@@ -5,14 +5,14 @@
 -export([
     start/3,
     start/4,
-    stop/0,
     stop/1
 ]).
 
 %% internal
 -export([
     init/0,
-    server/1
+    server/1,
+    terminate/0
 ]).
 
 %% public
@@ -37,9 +37,6 @@ start(Name, Client, ClientOptions, Options) ->
             start_children(Name, Client, ClientOptions, OptionsRec),
             ok
     end.
-
-stop() ->
-    foil:delete(?MODULE).
 
 -spec stop(pool_name()) ->
     ok | {error, shackle_not_started | pool_not_started}.
@@ -93,6 +90,12 @@ server(Name) ->
         {error, Reson} ->
             {error, Reson}
     end.
+
+-spec terminate() ->
+    ok.
+
+terminate() ->
+    foil:delete(?MODULE).
 
 %% private
 cleanup(Name, OptionsRec) ->

--- a/src/shackle_pool.erl
+++ b/src/shackle_pool.erl
@@ -5,6 +5,7 @@
 -export([
     start/3,
     start/4,
+    stop/0,
     stop/1
 ]).
 
@@ -36,6 +37,9 @@ start(Name, Client, ClientOptions, Options) ->
             start_children(Name, Client, ClientOptions, OptionsRec),
             ok
     end.
+
+stop() ->
+    foil:delete(?MODULE).
 
 -spec stop(pool_name()) ->
     ok | {error, shackle_not_started | pool_not_started}.

--- a/test/shackle_tests.erl
+++ b/test/shackle_tests.erl
@@ -211,12 +211,12 @@ app_stop_start_tcp_subtest() ->
     shackle_app:start(),
 
     shackle_pool:start(?POOL_NAME, ?CLIENT_TCP, [
-                {port, ?PORT},
-                {protocol, shackle_tcp},
-                {reconnect, true},
-                {reconnect_time_min, 1},
-                {socket_options, [binary, {packet, raw}]}
-            ], [{pool_size, 1}]),
+        {port, ?PORT},
+        {protocol, shackle_tcp},
+        {reconnect, true},
+        {reconnect_time_min, 1},
+        {socket_options, [binary, {packet, raw}]}
+    ], [{pool_size, 1}]),
 
     timer:sleep(100),
     ?assertEqual(2, arithmetic_tcp_client:add(1, 1)).


### PR DESCRIPTION
Fix for #82 

Unlike the ets tables the foil namespace lives on after the application stops and this breaks the ability to start the app again and create pools.