### PR TITLE
Wrap client calls in try/catch

### DIFF
--- a/doc/edoc-info
+++ b/doc/edoc-info
@@ -1,5 +1,5 @@
 %% encoding: UTF-8
 {application,shackle}.
 {modules,[shackle,shackle_app,shackle_backlog,shackle_backoff,shackle_client,
-          shackle_pool,shackle_queue,shackle_ssl_server,shackle_sup,
-          shackle_tcp_server,shackle_udp_server,shackle_utils]}.
+          shackle_pool,shackle_queue,shackle_server_utils,shackle_ssl_server,
+          shackle_sup,shackle_tcp_server,shackle_udp_server,shackle_utils]}.

--- a/doc/shackle_pool.md
+++ b/doc/shackle_pool.md
@@ -144,7 +144,7 @@ time() = pos_integer()
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#init-0">init/0</a></td><td></td></tr><tr><td valign="top"><a href="#server-1">server/1</a></td><td></td></tr><tr><td valign="top"><a href="#start-3">start/3</a></td><td></td></tr><tr><td valign="top"><a href="#start-4">start/4</a></td><td></td></tr><tr><td valign="top"><a href="#stop-1">stop/1</a></td><td></td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#init-0">init/0</a></td><td></td></tr><tr><td valign="top"><a href="#server-1">server/1</a></td><td></td></tr><tr><td valign="top"><a href="#start-3">start/3</a></td><td></td></tr><tr><td valign="top"><a href="#start-4">start/4</a></td><td></td></tr><tr><td valign="top"><a href="#stop-1">stop/1</a></td><td></td></tr><tr><td valign="top"><a href="#terminate-0">terminate/0</a></td><td></td></tr></table>
 
 
 <a name="functions"></a>
@@ -193,6 +193,15 @@ start(Name::<a href="#type-pool_name">pool_name()</a>, Client::<a href="#type-cl
 
 <pre><code>
 stop(Name::<a href="#type-pool_name">pool_name()</a>) -&gt; ok | {error, shackle_not_started | pool_not_started}
+</code></pre>
+<br />
+
+<a name="terminate-0"></a>
+
+### terminate/0 ###
+
+<pre><code>
+terminate() -&gt; ok
 </code></pre>
 <br />
 

--- a/doc/shackle_server_utils.md
+++ b/doc/shackle_server_utils.md
@@ -1,0 +1,286 @@
+
+
+# Module shackle_server_utils #
+* [Data Types](#types)
+* [Function Index](#index)
+* [Function Details](#functions)
+
+<a name="types"></a>
+
+## Data Types ##
+
+
+
+
+### <a name="type-backlog_size">backlog_size()</a> ###
+
+
+<pre><code>
+backlog_size() = pos_integer() | infinity
+</code></pre>
+
+
+
+
+### <a name="type-cast">cast()</a> ###
+
+
+<pre><code>
+cast() = #cast{client = <a href="#type-client">client()</a>, pid = undefined | pid(), request = term(), request_id = <a href="#type-request_id">request_id()</a>, timeout = timeout(), timestamp = <a href="erlang.md#type-timestamp">erlang:timestamp()</a>}
+</code></pre>
+
+
+
+
+### <a name="type-client">client()</a> ###
+
+
+<pre><code>
+client() = module()
+</code></pre>
+
+
+
+
+### <a name="type-client_option">client_option()</a> ###
+
+
+<pre><code>
+client_option() = {ip, <a href="inet.md#type-ip_address">inet:ip_address()</a> | <a href="inet.md#type-hostname">inet:hostname()</a>} | {port, <a href="inet.md#type-port_number">inet:port_number()</a>} | {protocol, <a href="#type-protocol">protocol()</a>} | {reconnect, boolean()} | {reconnect_time_max, <a href="#type-time">time()</a> | infinity} | {reconnect_time_min, <a href="#type-time">time()</a>} | {socket_options, [<a href="gen_tcp.md#type-connect_option">gen_tcp:connect_option()</a> | <a href="gen_udp.md#type-option">gen_udp:option()</a>]}
+</code></pre>
+
+
+
+
+### <a name="type-client_options">client_options()</a> ###
+
+
+<pre><code>
+client_options() = [<a href="#type-client_option">client_option()</a>]
+</code></pre>
+
+
+
+
+### <a name="type-client_state">client_state()</a> ###
+
+
+<pre><code>
+client_state() = term()
+</code></pre>
+
+
+
+
+### <a name="type-external_request_id">external_request_id()</a> ###
+
+
+<pre><code>
+external_request_id() = term()
+</code></pre>
+
+
+
+
+### <a name="type-pool_name">pool_name()</a> ###
+
+
+<pre><code>
+pool_name() = atom()
+</code></pre>
+
+
+
+
+### <a name="type-pool_option">pool_option()</a> ###
+
+
+<pre><code>
+pool_option() = {backlog_size, <a href="#type-backlog_size">backlog_size()</a>} | {pool_size, <a href="#type-pool_size">pool_size()</a>} | {pool_strategy, <a href="#type-pool_strategy">pool_strategy()</a>}
+</code></pre>
+
+
+
+
+### <a name="type-pool_options">pool_options()</a> ###
+
+
+<pre><code>
+pool_options() = [<a href="#type-pool_option">pool_option()</a>]
+</code></pre>
+
+
+
+
+### <a name="type-pool_size">pool_size()</a> ###
+
+
+<pre><code>
+pool_size() = pos_integer()
+</code></pre>
+
+
+
+
+### <a name="type-pool_strategy">pool_strategy()</a> ###
+
+
+<pre><code>
+pool_strategy() = random | round_robin
+</code></pre>
+
+
+
+
+### <a name="type-protocol">protocol()</a> ###
+
+
+<pre><code>
+protocol() = shackle_ssl | shackle_tcp | shackle_udp
+</code></pre>
+
+
+
+
+### <a name="type-reconnect_state">reconnect_state()</a> ###
+
+
+<pre><code>
+reconnect_state() = #reconnect_state{current = undefined | <a href="#type-time">time()</a>, max = <a href="#type-time">time()</a> | infinity, min = <a href="#type-time">time()</a>}
+</code></pre>
+
+
+
+
+### <a name="type-request_id">request_id()</a> ###
+
+
+<pre><code>
+request_id() = {<a href="#type-server_name">server_name()</a>, reference()}
+</code></pre>
+
+
+
+
+### <a name="type-response">response()</a> ###
+
+
+<pre><code>
+response() = {<a href="#type-external_request_id">external_request_id()</a>, term()}
+</code></pre>
+
+
+
+
+### <a name="type-server_name">server_name()</a> ###
+
+
+<pre><code>
+server_name() = atom()
+</code></pre>
+
+
+
+
+### <a name="type-socket">socket()</a> ###
+
+
+<pre><code>
+socket() = <a href="inet.md#type-socket">inet:socket()</a> | <a href="ssl.md#type-sslsocket">ssl:sslsocket()</a>
+</code></pre>
+
+
+
+
+### <a name="type-socket_type">socket_type()</a> ###
+
+
+<pre><code>
+socket_type() = inet | ssl
+</code></pre>
+
+
+
+
+### <a name="type-time">time()</a> ###
+
+
+<pre><code>
+time() = pos_integer()
+</code></pre>
+
+<a name="index"></a>
+
+## Function Index ##
+
+
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#cancel_timer-1">cancel_timer/1</a></td><td></td></tr><tr><td valign="top"><a href="#client-4">client/4</a></td><td></td></tr><tr><td valign="top"><a href="#process_responses-2">process_responses/2</a></td><td></td></tr><tr><td valign="top"><a href="#reconnect_state-1">reconnect_state/1</a></td><td></td></tr><tr><td valign="top"><a href="#reconnect_state_reset-1">reconnect_state_reset/1</a></td><td></td></tr><tr><td valign="top"><a href="#reply-3">reply/3</a></td><td></td></tr><tr><td valign="top"><a href="#reply_all-2">reply_all/2</a></td><td></td></tr></table>
+
+
+<a name="functions"></a>
+
+## Function Details ##
+
+<a name="cancel_timer-1"></a>
+
+### cancel_timer/1 ###
+
+<pre><code>
+cancel_timer(TimerRef::undefined | reference()) -&gt; ok
+</code></pre>
+<br />
+
+<a name="client-4"></a>
+
+### client/4 ###
+
+<pre><code>
+client(Client::<a href="#type-client">client()</a>, PoolName::<a href="#type-pool_name">pool_name()</a>, SocketType::<a href="#type-socket_type">socket_type()</a>, Socket::<a href="#type-socket">socket()</a>) -&gt; {ok, <a href="#type-client_state">client_state()</a>} | {error, term(), <a href="#type-client_state">client_state()</a>}
+</code></pre>
+<br />
+
+<a name="process_responses-2"></a>
+
+### process_responses/2 ###
+
+<pre><code>
+process_responses(T::[<a href="#type-response">response()</a>], Name::<a href="#type-server_name">server_name()</a>) -&gt; ok
+</code></pre>
+<br />
+
+<a name="reconnect_state-1"></a>
+
+### reconnect_state/1 ###
+
+<pre><code>
+reconnect_state(Options::<a href="#type-client_options">client_options()</a>) -&gt; undefined | <a href="#type-reconnect_state">reconnect_state()</a>
+</code></pre>
+<br />
+
+<a name="reconnect_state_reset-1"></a>
+
+### reconnect_state_reset/1 ###
+
+<pre><code>
+reconnect_state_reset(Reconnect_state::undefined | <a href="#type-reconnect_state">reconnect_state()</a>) -&gt; undefined | <a href="#type-reconnect_state">reconnect_state()</a>
+</code></pre>
+<br />
+
+<a name="reply-3"></a>
+
+### reply/3 ###
+
+<pre><code>
+reply(Name::<a href="#type-server_name">server_name()</a>, Reply::term(), Cast::undefined | <a href="#type-cast">cast()</a>) -&gt; ok
+</code></pre>
+<br />
+
+<a name="reply_all-2"></a>
+
+### reply_all/2 ###
+
+<pre><code>
+reply_all(Name::<a href="#type-server_name">server_name()</a>, Reply::term()) -&gt; ok
+</code></pre>
+<br />
+

--- a/doc/shackle_ssl_server.md
+++ b/doc/shackle_ssl_server.md
@@ -166,7 +166,7 @@ server_name() = atom()
 
 
 <pre><code>
-state() = #state{client = <a href="#type-client">client()</a>, ip = <a href="inet.md#type-ip_address">inet:ip_address()</a> | <a href="inet.md#type-hostname">inet:hostname()</a>, name = <a href="#type-server_name">server_name()</a>, parent = pid(), pool_name = <a href="#type-pool_name">pool_name()</a>, port = <a href="inet.md#type-port_number">inet:port_number()</a>, reconnect_state = undefined | <a href="#type-reconnect_state">reconnect_state()</a>, socket = undefined | <a href="inet.md#type-socket">inet:socket()</a>, socket_options = [<a href="ssl.md#type-connect_option">ssl:connect_option()</a>], timer_ref = undefined | reference()}
+state() = #state{client = <a href="#type-client">client()</a>, ip = <a href="inet.md#type-ip_address">inet:ip_address()</a> | <a href="inet.md#type-hostname">inet:hostname()</a>, name = <a href="#type-server_name">server_name()</a>, parent = pid(), pool_name = <a href="#type-pool_name">pool_name()</a>, port = <a href="inet.md#type-port_number">inet:port_number()</a>, reconnect_state = undefined | <a href="#type-reconnect_state">reconnect_state()</a>, socket = undefined | <a href="ssl.md#type-sslsocket">ssl:sslsocket()</a>, socket_options = [<a href="ssl.md#type-connect_option">ssl:connect_option()</a>], timer_ref = undefined | reference()}
 </code></pre>
 
 

--- a/doc/shackle_utils.md
+++ b/doc/shackle_utils.md
@@ -22,26 +22,6 @@ backlog_size() = pos_integer() | infinity
 
 
 
-### <a name="type-cast">cast()</a> ###
-
-
-<pre><code>
-cast() = #cast{client = <a href="#type-client">client()</a>, pid = undefined | pid(), request = term(), request_id = <a href="#type-request_id">request_id()</a>, timeout = timeout(), timestamp = <a href="erlang.md#type-timestamp">erlang:timestamp()</a>}
-</code></pre>
-
-
-
-
-### <a name="type-client">client()</a> ###
-
-
-<pre><code>
-client() = module()
-</code></pre>
-
-
-
-
 ### <a name="type-client_option">client_option()</a> ###
 
 
@@ -57,26 +37,6 @@ client_option() = {ip, <a href="inet.md#type-ip_address">inet:ip_address()</a> |
 
 <pre><code>
 client_options() = [<a href="#type-client_option">client_option()</a>]
-</code></pre>
-
-
-
-
-### <a name="type-client_state">client_state()</a> ###
-
-
-<pre><code>
-client_state() = term()
-</code></pre>
-
-
-
-
-### <a name="type-external_request_id">external_request_id()</a> ###
-
-
-<pre><code>
-external_request_id() = term()
 </code></pre>
 
 
@@ -142,31 +102,11 @@ protocol() = shackle_ssl | shackle_tcp | shackle_udp
 
 
 
-### <a name="type-reconnect_state">reconnect_state()</a> ###
-
-
-<pre><code>
-reconnect_state() = #reconnect_state{current = undefined | <a href="#type-time">time()</a>, max = <a href="#type-time">time()</a> | infinity, min = <a href="#type-time">time()</a>}
-</code></pre>
-
-
-
-
 ### <a name="type-request_id">request_id()</a> ###
 
 
 <pre><code>
 request_id() = {<a href="#type-server_name">server_name()</a>, reference()}
-</code></pre>
-
-
-
-
-### <a name="type-response">response()</a> ###
-
-
-<pre><code>
-response() = {<a href="#type-external_request_id">external_request_id()</a>, term()}
 </code></pre>
 
 
@@ -194,30 +134,12 @@ time() = pos_integer()
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#cancel_timer-1">cancel_timer/1</a></td><td></td></tr><tr><td valign="top"><a href="#client_setup-3">client_setup/3</a></td><td></td></tr><tr><td valign="top"><a href="#lookup-3">lookup/3</a></td><td></td></tr><tr><td valign="top"><a href="#process_responses-2">process_responses/2</a></td><td></td></tr><tr><td valign="top"><a href="#random-1">random/1</a></td><td></td></tr><tr><td valign="top"><a href="#random_element-1">random_element/1</a></td><td></td></tr><tr><td valign="top"><a href="#reconnect_state-1">reconnect_state/1</a></td><td></td></tr><tr><td valign="top"><a href="#reconnect_state_reset-1">reconnect_state_reset/1</a></td><td></td></tr><tr><td valign="top"><a href="#reply-3">reply/3</a></td><td></td></tr><tr><td valign="top"><a href="#reply_all-2">reply_all/2</a></td><td></td></tr><tr><td valign="top"><a href="#warning_msg-3">warning_msg/3</a></td><td></td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#lookup-3">lookup/3</a></td><td></td></tr><tr><td valign="top"><a href="#random-1">random/1</a></td><td></td></tr><tr><td valign="top"><a href="#random_element-1">random_element/1</a></td><td></td></tr><tr><td valign="top"><a href="#warning_msg-3">warning_msg/3</a></td><td></td></tr></table>
 
 
 <a name="functions"></a>
 
 ## Function Details ##
-
-<a name="cancel_timer-1"></a>
-
-### cancel_timer/1 ###
-
-<pre><code>
-cancel_timer(TimerRef::undefined | reference()) -&gt; ok
-</code></pre>
-<br />
-
-<a name="client_setup-3"></a>
-
-### client_setup/3 ###
-
-<pre><code>
-client_setup(Client::<a href="#type-client">client()</a>, PoolName::<a href="#type-pool_name">pool_name()</a>, Socket::<a href="inet.md#type-socket">inet:socket()</a>) -&gt; {ok, <a href="#type-client_state">client_state()</a>} | {error, term(), <a href="#type-client_state">client_state()</a>}
-</code></pre>
-<br />
 
 <a name="lookup-3"></a>
 
@@ -225,15 +147,6 @@ client_setup(Client::<a href="#type-client">client()</a>, PoolName::<a href="#ty
 
 <pre><code>
 lookup(Key::atom(), List::[{atom(), term()}], Default::term()) -&gt; term()
-</code></pre>
-<br />
-
-<a name="process_responses-2"></a>
-
-### process_responses/2 ###
-
-<pre><code>
-process_responses(T::[<a href="#type-response">response()</a>], Name::<a href="#type-server_name">server_name()</a>) -&gt; ok
 </code></pre>
 <br />
 
@@ -252,42 +165,6 @@ random(N::pos_integer()) -&gt; non_neg_integer()
 
 <pre><code>
 random_element(List::[term()]) -&gt; term()
-</code></pre>
-<br />
-
-<a name="reconnect_state-1"></a>
-
-### reconnect_state/1 ###
-
-<pre><code>
-reconnect_state(Options::<a href="#type-client_options">client_options()</a>) -&gt; undefined | <a href="#type-reconnect_state">reconnect_state()</a>
-</code></pre>
-<br />
-
-<a name="reconnect_state_reset-1"></a>
-
-### reconnect_state_reset/1 ###
-
-<pre><code>
-reconnect_state_reset(Reconnect_state::undefined | <a href="#type-reconnect_state">reconnect_state()</a>) -&gt; undefined | <a href="#type-reconnect_state">reconnect_state()</a>
-</code></pre>
-<br />
-
-<a name="reply-3"></a>
-
-### reply/3 ###
-
-<pre><code>
-reply(Name::<a href="#type-server_name">server_name()</a>, Reply::term(), Cast::undefined | <a href="#type-cast">cast()</a>) -&gt; ok
-</code></pre>
-<br />
-
-<a name="reply_all-2"></a>
-
-### reply_all/2 ###
-
-<pre><code>
-reply_all(Name::<a href="#type-server_name">server_name()</a>, Reply::term()) -&gt; ok
 </code></pre>
 <br />
 

--- a/elvis.config
+++ b/elvis.config
@@ -9,7 +9,8 @@
             shackle_ssl_server,
             shackle_tcp_server,
             shackle_udp_server,
-            shackle_utils
+            shackle_utils,
+            shackle_tests
         ]}},
         {elvis_style, line_length, #{limit => 80, skip_comments => false}},
         {elvis_style, macro_names},

--- a/include/shackle.hrl
+++ b/include/shackle.hrl
@@ -50,6 +50,8 @@
 -type request_id() :: {server_name(), reference()}.
 -type response() :: {external_request_id(), term()}.
 -type server_name() :: atom().
+-type socket() :: inet:socket() | ssl:sslsocket().
+-type socket_type() :: inet | ssl.
 -type time() :: pos_integer().
 
 -export_type([

--- a/include/shackle_internal.hrl
+++ b/include/shackle_internal.hrl
@@ -8,6 +8,8 @@
 -define(MSG_CONNECT, connect).
 -define(SERVER, shackle_server).
 -define(SUPERVISOR, shackle_sup).
+-define(SERVER_UTILS, shackle_server_utils).
+-define(WARN(PoolName, Format, Data), shackle_utils:warning_msg(PoolName, Format, Data)).
 
 %% ETS tables
 -define(ETS_TABLE_BACKLOG, shackle_backlog).

--- a/src/shackle_client.erl
+++ b/src/shackle_client.erl
@@ -2,7 +2,8 @@
 -include("shackle_internal.hrl").
 
 -callback init() ->
-    {ok, State :: term()}.
+    {ok, State :: term()} |
+    {error, Reason :: term()}.
 
 -callback setup(Socket :: inet:socket(), State :: term()) ->
     {ok, State :: term()} |

--- a/src/shackle_server_utils.erl
+++ b/src/shackle_server_utils.erl
@@ -1,0 +1,136 @@
+-module(shackle_server_utils).
+-include("shackle_internal.hrl").
+
+-compile(inline).
+-compile({inline_size, 512}).
+
+%% public
+-export([
+    cancel_timer/1,
+    client/4,
+    process_responses/2,
+    reconnect_state/1,
+    reconnect_state_reset/1,
+    reply/3,
+    reply_all/2
+]).
+
+%% public
+-spec cancel_timer(undefined | reference()) ->
+    ok.
+
+cancel_timer(undefined) ->
+    ok;
+cancel_timer(TimerRef) ->
+    erlang:cancel_timer(TimerRef).
+
+-spec client(client(), pool_name(), socket_type(), socket()) ->
+    {ok, client_state()} | {error, term(), client_state()}.
+
+client(Client, PoolName, SocketType, Socket) ->
+    case client_init(Client, PoolName) of
+        {ok, ClientState} ->
+            client_setup(Client, PoolName, SocketType, Socket, ClientState);
+        {error, Reason} ->
+            {error, Reason, undefined}
+    end.
+
+-spec process_responses([response()], server_name()) ->
+    ok.
+
+process_responses([], _Name) ->
+    ok;
+process_responses([{ExtRequestId, Reply} | T], Name) ->
+    case shackle_queue:remove(Name, ExtRequestId) of
+        {ok, Cast, TimerRef} ->
+            erlang:cancel_timer(TimerRef),
+            reply(Name, Reply, Cast);
+        {error, not_found} ->
+            ok
+    end,
+    process_responses(T, Name).
+
+-spec reconnect_state(client_options()) ->
+    undefined | reconnect_state().
+
+reconnect_state(Options) ->
+    Reconnect = ?LOOKUP(reconnect, Options, ?DEFAULT_RECONNECT),
+    case Reconnect of
+        true ->
+            Max = ?LOOKUP(reconnect_time_max, Options,
+                ?DEFAULT_RECONNECT_MAX),
+            Min = ?LOOKUP(reconnect_time_min, Options,
+                ?DEFAULT_RECONNECT_MIN),
+
+            #reconnect_state {
+                min = Min,
+                max = Max
+            };
+        false ->
+            undefined
+    end.
+
+-spec reconnect_state_reset(undefined | reconnect_state()) ->
+    undefined | reconnect_state().
+
+reconnect_state_reset(undefined) ->
+    undefined;
+reconnect_state_reset(#reconnect_state {} = ReconnectState) ->
+    ReconnectState#reconnect_state {
+        current = undefined
+    }.
+
+-spec reply(server_name(), term(), undefined | cast()) ->
+    ok.
+
+reply(Name, _Reply, #cast {pid = undefined}) ->
+    shackle_backlog:decrement(Name),
+    ok;
+reply(Name, Reply, #cast {pid = Pid} = Cast) ->
+    shackle_backlog:decrement(Name),
+    Pid ! {Cast, Reply},
+    ok.
+
+-spec reply_all(server_name(), term()) ->
+    ok.
+
+reply_all(Name, Reply) ->
+    reply_all(Name, Reply, shackle_queue:clear(Name)).
+
+%% private
+client_init(Client, PoolName) ->
+    try Client:init() of
+        {ok, ClientState} ->
+            {ok, ClientState};
+        {error, Reason} ->
+            ?WARN(PoolName, "init error: ~p~n", [Reason]),
+            {error, Reason}
+    catch
+        E:R ->
+            ?WARN(PoolName, "init crash: ~p:~p~n~p~n",
+                [E, R, erlang:get_stacktrace()]),
+            {error, client_crash}
+    end.
+
+client_setup(Client, PoolName, SocketType, Socket, ClientState) ->
+    SocketType:setopts(Socket, [{active, false}]),
+    try Client:setup(Socket, ClientState) of
+        {ok, ClientState2} ->
+            SocketType:setopts(Socket, [{active, true}]),
+            {ok, ClientState2};
+        {error, Reason, ClientState2} ->
+            ?WARN(PoolName, "setup error: ~p", [Reason]),
+            {error, Reason, ClientState2}
+    catch
+        E:R ->
+            ?WARN(PoolName, "handle_data error: ~p:~p~n~p~n",
+                [E, R, erlang:get_stacktrace()]),
+            {error, client_crash, ClientState}
+    end.
+
+reply_all(_Name, _Reply, []) ->
+    ok;
+reply_all(Name, Reply, [{Cast, TimerRef} | T]) ->
+    erlang:cancel_timer(TimerRef),
+    reply(Name, Reply, Cast),
+    reply_all(Name, Reply, T).

--- a/src/shackle_tcp_server.erl
+++ b/src/shackle_tcp_server.erl
@@ -45,7 +45,7 @@ init(Name, Parent, Opts) ->
 
     Ip = ?LOOKUP(ip, ClientOptions, ?DEFAULT_IP),
     Port = ?LOOKUP(port, ClientOptions),
-    ReconnectState = shackle_utils:reconnect_state(ClientOptions),
+    ReconnectState = ?SERVER_UTILS:reconnect_state(ClientOptions),
     SocketOptions = ?LOOKUP(socket_options, ClientOptions,
         ?DEFAULT_SOCKET_OPTS),
 
@@ -68,7 +68,7 @@ handle_msg(#cast {} = Cast, {#state {
         name = Name
     } = State, ClientState}) ->
 
-    shackle_utils:reply(Name, {error, no_socket}, Cast),
+    ?SERVER_UTILS:reply(Name, {error, no_socket}, Cast),
     {ok, {State, ClientState}};
 handle_msg(#cast {
         request = Request,
@@ -80,20 +80,26 @@ handle_msg(#cast {
         socket = Socket
     } = State, ClientState}) ->
 
-    {ok, ExtRequestId, Data, ClientState2} =
-        Client:handle_request(Request, ClientState),
-
-    case gen_tcp:send(Socket, Data) of
-        ok ->
-            Msg = {timeout, ExtRequestId},
-            TimerRef = erlang:send_after(Timeout, self(), Msg),
-            shackle_queue:add(ExtRequestId, Cast, TimerRef),
-            {ok, {State, ClientState2}};
-        {error, Reason} ->
-            shackle_utils:warning_msg(PoolName, "send error: ~p", [Reason]),
-            gen_tcp:close(Socket),
-            shackle_utils:reply(Name, {error, socket_closed}, Cast),
-            close(State, ClientState2)
+    try Client:handle_request(Request, ClientState) of
+        {ok, ExtRequestId, Data, ClientState2} ->
+            case gen_tcp:send(Socket, Data) of
+                ok ->
+                    Msg = {timeout, ExtRequestId},
+                    TimerRef = erlang:send_after(Timeout, self(), Msg),
+                    shackle_queue:add(ExtRequestId, Cast, TimerRef),
+                    {ok, {State, ClientState2}};
+                {error, Reason} ->
+                    ?WARN(PoolName, "send error: ~p", [Reason]),
+                    gen_tcp:close(Socket),
+                    ?SERVER_UTILS:reply(Name, {error, socket_closed}, Cast),
+                    close(State, ClientState2)
+            end
+    catch
+        E:R ->
+            ?WARN(PoolName, "handle_request crash: ~p:~p~n~p~n",
+                [E, R, erlang:get_stacktrace()]),
+            ?SERVER_UTILS:reply(Name, {error, client_crash}, Cast),
+            {ok, {State, ClientState}}
     end;
 handle_msg({tcp, Socket, Data}, {#state {
         client = Client,
@@ -102,15 +108,20 @@ handle_msg({tcp, Socket, Data}, {#state {
         socket = Socket
     } = State, ClientState}) ->
 
-    case Client:handle_data(Data, ClientState) of
+    try Client:handle_data(Data, ClientState) of
         {ok, Replies, ClientState2} ->
-            shackle_utils:process_responses(Replies, Name),
+            ?SERVER_UTILS:process_responses(Replies, Name),
             {ok, {State, ClientState2}};
         {error, Reason, ClientState2} ->
-            shackle_utils:warning_msg(PoolName,
-                "handle_data error: ~p", [Reason]),
+            ?WARN(PoolName, "handle_data error: ~p", [Reason]),
             gen_tcp:close(Socket),
             close(State, ClientState2)
+    catch
+        E:R ->
+            ?WARN(PoolName, "handle_data crash: ~p:~p~n~p~n",
+                [E, R, erlang:get_stacktrace()]),
+            gen_tcp:close(Socket),
+            close(State, ClientState)
     end;
 handle_msg({timeout, ExtRequestId}, {#state {
         name = Name
@@ -118,7 +129,7 @@ handle_msg({timeout, ExtRequestId}, {#state {
 
     case shackle_queue:remove(Name, ExtRequestId) of
         {ok, Cast, _TimerRef} ->
-            shackle_utils:reply(Name, {error, timeout}, Cast);
+            ?SERVER_UTILS:reply(Name, {error, timeout}, Cast);
         {error, not_found} ->
             ok
     end,
@@ -128,14 +139,14 @@ handle_msg({tcp_closed, Socket}, {#state {
         pool_name = PoolName
     } = State, ClientState}) ->
 
-    shackle_utils:warning_msg(PoolName, "connection closed", []),
+    ?WARN(PoolName, "connection closed", []),
     close(State, ClientState);
 handle_msg({tcp_error, Socket, Reason}, {#state {
         socket = Socket,
         pool_name = PoolName
     } = State, ClientState}) ->
 
-    shackle_utils:warning_msg(PoolName, "connection error: ~p", [Reason]),
+    ?WARN(PoolName, "connection error: ~p", [Reason]),
     gen_tcp:close(Socket),
     close(State, ClientState);
 handle_msg(?MSG_CONNECT, {#state {
@@ -149,10 +160,10 @@ handle_msg(?MSG_CONNECT, {#state {
 
     case connect(PoolName, Ip, Port, SocketOptions) of
         {ok, Socket} ->
-            case shackle_utils:client_setup(Client, PoolName, Socket) of
+            case ?SERVER_UTILS:client(Client, PoolName, inet, Socket) of
                 {ok, ClientState2} ->
                     ReconnectState2 =
-                        shackle_utils:reconnect_state_reset(ReconnectState),
+                        ?SERVER_UTILS:reconnect_state_reset(ReconnectState),
 
                     {ok, {State#state {
                         reconnect_state = ReconnectState2,
@@ -169,7 +180,7 @@ handle_msg(Msg, {#state {
         pool_name = PoolName
     } = State, ClientState}) ->
 
-    shackle_utils:warning_msg(PoolName, "unknown msg: ~p", [Msg]),
+    ?WARN(PoolName, "unknown msg: ~p", [Msg]),
     {ok, {State, ClientState}}.
 
 -spec terminate(term(), term()) ->
@@ -178,18 +189,24 @@ handle_msg(Msg, {#state {
 terminate(_Reason, {#state {
         client = Client,
         name = Name,
+        pool_name = PoolName,
         timer_ref = TimerRef
     }, ClientState}) ->
 
-    shackle_utils:cancel_timer(TimerRef),
-    ok = Client:terminate(ClientState),
-    shackle_utils:reply_all(Name, {error, shutdown}),
+    ?SERVER_UTILS:cancel_timer(TimerRef),
+    try Client:terminate(ClientState)
+    catch
+        E:R ->
+            ?WARN(PoolName, "terminate crash: ~p:~p~n~p~n",
+                [E, R, erlang:get_stacktrace()])
+    end,
+    ?SERVER_UTILS:reply_all(Name, {error, shutdown}),
     shackle_backlog:delete(Name),
     ok.
 
 %% private
 close(#state {name = Name} = State, ClientState) ->
-    shackle_utils:reply_all(Name, {error, socket_closed}),
+    ?SERVER_UTILS:reply_all(Name, {error, socket_closed}),
     reconnect(State, ClientState).
 
 connect(PoolName, Ip, Port, SocketOptions) ->
@@ -201,23 +218,27 @@ connect(PoolName, Ip, Port, SocketOptions) ->
                 {ok, Socket} ->
                     {ok, Socket};
                 {error, Reason} ->
-                    shackle_utils:warning_msg(PoolName,
-                        "connect error: ~p", [Reason]),
+                    ?WARN(PoolName, "connect error: ~p", [Reason]),
                     {error, Reason}
             end;
         {error, Reason} ->
-            shackle_utils:warning_msg(PoolName,
-                "getaddrs error: ~p", [Reason]),
+            ?WARN(PoolName, "getaddrs error: ~p", [Reason]),
             {error, Reason}
     end.
 
 reconnect(State, undefined) ->
     reconnect_timer(State, undefined);
 reconnect(#state {
-        client = Client
+        client = Client,
+        pool_name = PoolName
     } = State, ClientState) ->
 
-    ok = Client:terminate(ClientState),
+    try Client:terminate(ClientState)
+    catch
+        E:R ->
+            ?WARN(PoolName, "terminate crash: ~p:~p~n~p~n",
+                [E, R, erlang:get_stacktrace()])
+    end,
     reconnect_timer(State, ClientState).
 
 reconnect_timer(#state {

--- a/src/shackle_utils.erl
+++ b/src/shackle_utils.erl
@@ -6,44 +6,13 @@
 
 %% public
 -export([
-    cancel_timer/1,
-    client_setup/3,
     lookup/3,
-    process_responses/2,
     random/1,
     random_element/1,
-    warning_msg/3,
-    reconnect_state/1,
-    reconnect_state_reset/1,
-    reply/3,
-    reply_all/2
+    warning_msg/3
 ]).
 
 %% public
--spec cancel_timer(undefined | reference()) ->
-    ok.
-
-cancel_timer(undefined) ->
-    ok;
-cancel_timer(TimerRef) ->
-    erlang:cancel_timer(TimerRef).
-
--spec client_setup(client(), pool_name(), inet:socket()) ->
-    {ok, client_state()} | {error, term(), client_state()}.
-
-client_setup(Client, PoolName, Socket) ->
-    {ok, ClientState} = Client:init(),
-    inet:setopts(Socket, [{active, false}]),
-    case Client:setup(Socket, ClientState) of
-        {ok, ClientState2} ->
-            inet:setopts(Socket, [{active, true}]),
-            {ok, ClientState2};
-        {error, Reason, ClientState2} ->
-            shackle_utils:warning_msg(PoolName,
-                "setup error: ~p", [Reason]),
-            {error, Reason, ClientState2}
-    end.
-
 -spec lookup(atom(), [{atom(), term()}], term()) ->
     term().
 
@@ -52,21 +21,6 @@ lookup(Key, List, Default) ->
         false -> Default;
         {_, Value} -> Value
     end.
-
--spec process_responses([response()], server_name()) ->
-    ok.
-
-process_responses([], _Name) ->
-    ok;
-process_responses([{ExtRequestId, Reply} | T], Name) ->
-    case shackle_queue:remove(Name, ExtRequestId) of
-        {ok, Cast, TimerRef} ->
-            erlang:cancel_timer(TimerRef),
-            reply(Name, Reply, Cast);
-        {error, not_found} ->
-            ok
-    end,
-    process_responses(T, Name).
 
 -spec random(pos_integer()) ->
     non_neg_integer().
@@ -84,63 +38,8 @@ random_element([_|_] = List) ->
     T = list_to_tuple(List),
     element(random(tuple_size(T)), T).
 
--spec reconnect_state(client_options()) ->
-    undefined | reconnect_state().
-
-reconnect_state(Options) ->
-    Reconnect = ?LOOKUP(reconnect, Options, ?DEFAULT_RECONNECT),
-    case Reconnect of
-        true ->
-            Max = ?LOOKUP(reconnect_time_max, Options,
-                ?DEFAULT_RECONNECT_MAX),
-            Min = ?LOOKUP(reconnect_time_min, Options,
-                ?DEFAULT_RECONNECT_MIN),
-
-            #reconnect_state {
-                min = Min,
-                max = Max
-            };
-        false ->
-            undefined
-    end.
-
--spec reconnect_state_reset(undefined | reconnect_state()) ->
-    undefined | reconnect_state().
-
-reconnect_state_reset(undefined) ->
-    undefined;
-reconnect_state_reset(#reconnect_state {} = ReconnectState) ->
-    ReconnectState#reconnect_state {
-        current = undefined
-    }.
-
--spec reply(server_name(), term(), undefined | cast()) ->
-    ok.
-
-reply(Name, _Reply, #cast {pid = undefined}) ->
-    shackle_backlog:decrement(Name),
-    ok;
-reply(Name, Reply, #cast {pid = Pid} = Cast) ->
-    shackle_backlog:decrement(Name),
-    Pid ! {Cast, Reply},
-    ok.
-
--spec reply_all(server_name(), term()) ->
-    ok.
-
-reply_all(Name, Reply) ->
-    reply_all(Name, Reply, shackle_queue:clear(Name)).
-
 -spec warning_msg(pool_name(), string(), [term()]) ->
     ok.
 
 warning_msg(Pool, Format, Data) ->
     error_logger:warning_msg("[~p] " ++ Format, [Pool | Data]).
-
-%% private
-reply_all(_Name, _Reply, []) ->
-    ok;
-reply_all(Name, Reply, [{Cast, TimerRef} | T]) ->
-    erlang:cancel_timer(TimerRef),
-    reply(Name, Reply, Cast),
-    reply_all(Name, Reply, T).

--- a/test/arithmetic_ssl_client.erl
+++ b/test/arithmetic_ssl_client.erl
@@ -1,5 +1,6 @@
 -module(arithmetic_ssl_client).
 -include("test.hrl").
+-include_lib("shackle/include/shackle.hrl").
 
 -export([
     add/2,
@@ -42,24 +43,25 @@ multiply(A, B) ->
     ok | {error, shackle_not_started | pool_already_started}.
 
 start() ->
-    start(1).
+    start([
+        {backlog_size, ?BACKLOG_SIZE},
+        {pool_size, 1}
+    ]).
 
--spec start(pos_integer()) ->
+-spec start(pool_options()) ->
     ok | {error, shackle_not_started | pool_already_started}.
 
-start(PoolSize) ->
+start(PoolOptions) ->
     shackle_pool:start(?POOL_NAME, ?CLIENT_SSL, [
         {port, ?PORT},
         {protocol, shackle_ssl},
         {reconnect, true},
+        {reconnect_time_min, 1},
         {socket_options, [
             binary,
             {packet, raw}
         ]}
-    ], [
-        {backlog_size, ?BACKLOG_SIZE},
-        {pool_size, PoolSize}
-    ]).
+    ], PoolOptions).
 
 -spec stop() ->
     ok | {error, pool_not_started}.

--- a/test/arithmetic_tcp_client.erl
+++ b/test/arithmetic_tcp_client.erl
@@ -1,5 +1,6 @@
 -module(arithmetic_tcp_client).
 -include("test.hrl").
+-include_lib("shackle/include/shackle.hrl").
 
 -export([
     add/2,
@@ -42,23 +43,24 @@ multiply(A, B) ->
     ok | {error, shackle_not_started | pool_already_started}.
 
 start() ->
-    start(?POOL_SIZE).
+    start([
+        {backlog_size, ?BACKLOG_SIZE},
+        {pool_size, 1}
+    ]).
 
--spec start(pos_integer()) ->
+-spec start(pool_options()) ->
     ok | {error, shackle_not_started | pool_already_started}.
 
-start(PoolSize) ->
+start(PoolOptions) ->
     shackle_pool:start(?POOL_NAME, ?CLIENT_TCP, [
         {port, ?PORT},
         {reconnect, true},
+        {reconnect_time_min, 1},
         {socket_options, [
             binary,
             {packet, raw}
         ]}
-    ], [
-        {backlog_size, ?BACKLOG_SIZE},
-        {pool_size, PoolSize}
-    ]).
+    ], PoolOptions).
 
 -spec stop() ->
     ok | {error, pool_not_started}.

--- a/test/arithmetic_udp_client.erl
+++ b/test/arithmetic_udp_client.erl
@@ -1,5 +1,6 @@
 -module(arithmetic_udp_client).
 -include("test.hrl").
+-include_lib("shackle/include/shackle.hrl").
 
 -export([
     add/2,
@@ -42,23 +43,24 @@ multiply(A, B) ->
     ok | {error, shackle_not_started | pool_already_started}.
 
 start() ->
-    start(?POOL_SIZE).
+    start([
+        {backlog_size, ?BACKLOG_SIZE},
+        {pool_size, 1}
+    ]).
 
--spec start(pos_integer()) ->
+-spec start(pool_options()) ->
     ok | {error, shackle_not_started | pool_already_started}.
 
-start(PoolSize) ->
+start(PoolOptions) ->
     shackle_pool:start(?POOL_NAME, ?CLIENT_UDP, [
         {port, ?PORT},
         {protocol, shackle_udp},
         {reconnect, true},
+        {reconnect_time_min, 1},
         {socket_options, [
             binary
         ]}
-    ], [
-        {backlog_size, ?BACKLOG_SIZE},
-        {pool_size, PoolSize}
-    ]).
+    ], PoolOptions).
 
 -spec stop() ->
     ok | {error, pool_not_started}.

--- a/test/shackle_tests.erl
+++ b/test/shackle_tests.erl
@@ -5,155 +5,157 @@
 -define(N, 1000).
 
 %% runners
+shackle_app_stop_start_test_() ->
+    {setup,
+        fun () ->
+            setup(),
+            ?CLIENT_TCP:start()
+        end,
+        fun (_) -> cleanup(?CLIENT_TCP) end,
+    [fun app_stop_start_subtest/0]}.
+
 shackle_backlog_test_() ->
     {setup,
         fun () ->
-            setup_tcp([
+            setup(?CLIENT_TCP, [
                 {backlog_size, 1},
                 {pool_size, 1}
             ])
         end,
-        fun (_) -> cleanup_tcp() end,
+        fun (_) -> cleanup(?CLIENT_TCP) end,
     [fun backlog_full_subtest/0]}.
 
 shackle_backlog_infinity_test_() ->
     {setup,
         fun () ->
-            setup_tcp([
+            setup(?CLIENT_TCP, [
                 {backlog_size, infinity},
                 {pool_size, 1}
             ])
         end,
-        fun (_) -> cleanup_tcp() end,
-    [fun add_tcp_subtest/0]}.
+        fun (_) -> cleanup(?CLIENT_TCP) end,
+    [fun () -> add_subtest(?CLIENT_TCP) end]}.
+
+shackle_call_crash_test_() ->
+    {setup,
+        fun () ->
+            setup(?CLIENT_TCP, [
+                {pool_size, 1}
+            ])
+        end,
+        fun (_) -> cleanup(?CLIENT_TCP) end,
+    [fun call_crash_subtest/0]}.
 
 shackle_random_ssl_test_() ->
     {setup,
-        fun () -> setup_ssl([
-            {pool_size, 1},
-            {pool_strategy, random}
+        fun () ->
+            setup(?CLIENT_SSL, [
+                {pool_size, 1},
+                {pool_strategy, random}
         ]) end,
-        fun (_) -> cleanup_ssl() end,
+        fun (_) -> cleanup(?CLIENT_SSL) end,
     {inparallel, [
-        fun add_ssl_subtest/0,
-        fun multiply_ssl_subtest/0
+        fun () -> add_subtest(?CLIENT_SSL) end,
+        fun () -> multiply_subtest(?CLIENT_SSL) end
     ]}}.
 
 shackle_random_tcp_test_() ->
     {setup,
-        fun () -> setup_tcp([
-            {pool_size, 1},
-            {pool_strategy, random}
-        ]) end,
-        fun (_) -> cleanup_tcp() end,
+        fun () ->
+            setup(?CLIENT_TCP, [
+                {pool_size, 1},
+                {pool_strategy, random}
+            ])
+        end,
+        fun (_) -> cleanup(?CLIENT_TCP) end,
     {inparallel, [
-        fun add_tcp_subtest/0,
-        fun multiply_tcp_subtest/0
+        fun () -> add_subtest(?CLIENT_TCP) end,
+        fun () -> multiply_subtest(?CLIENT_TCP) end
     ]}}.
 
 shackle_random_udp_test_() ->
     {setup,
-        fun () -> setup_udp([
-            {pool_size, 1},
-            {pool_strategy, random}
-        ]) end,
-        fun (_) -> cleanup_udp() end,
+        fun () ->
+            setup(?CLIENT_UDP, [
+                {pool_size, 1},
+                {pool_strategy, random}
+            ])
+        end,
+        fun (_) -> cleanup(?CLIENT_UDP) end,
     {inparallel, [
-        fun add_udp_subtest/0,
-        fun multiply_udp_subtest/0
+        fun () -> add_subtest(?CLIENT_UDP) end,
+        fun () -> multiply_subtest(?CLIENT_UDP) end
     ]}}.
 
 shackle_reconnect_ssl_test_() ->
     {setup,
         fun () ->
             setup(),
-            shackle_pool:start(?POOL_NAME, ?CLIENT_SSL, [
-                {port, ?PORT},
-                {protocol, shackle_ssl},
-                {reconnect, true},
-                {reconnect_time_min, 1},
-                {socket_options, [binary, {packet, raw}]}
-            ], [{pool_size, 1}])
+            ?CLIENT_SSL:start()
         end,
-        fun (_) -> cleanup_ssl() end,
-    [fun reconnect_ssl_subtest/0]}.
+        fun (_) -> cleanup(?CLIENT_SSL) end,
+    [fun () -> reconnect_subtest(?CLIENT_SSL) end]}.
 
 shackle_reconnect_tcp_test_() ->
     {setup,
         fun () ->
             setup(),
-            shackle_pool:start(?POOL_NAME, ?CLIENT_TCP, [
-                {port, ?PORT},
-                {protocol, shackle_tcp},
-                {reconnect, true},
-                {reconnect_time_min, 1},
-                {socket_options, [binary, {packet, raw}]}
-            ], [{pool_size, 1}])
+            ?CLIENT_TCP:start()
         end,
-        fun (_) -> cleanup_tcp() end,
-    [fun reconnect_tcp_subtest/0]}.
-
-shackle_app_stop_start_tcp_test_() ->
-    {setup,
-        fun () ->
-            setup(),
-            shackle_pool:start(?POOL_NAME, ?CLIENT_TCP, [
-                {port, ?PORT},
-                {protocol, shackle_tcp},
-                {reconnect, true},
-                {reconnect_time_min, 1},
-                {socket_options, [binary, {packet, raw}]}
-            ], [{pool_size, 1}])
-        end,
-        fun (_) -> cleanup_tcp() end,
-    [fun app_stop_start_tcp_subtest/0]}.
+        fun (_) -> cleanup(?CLIENT_TCP) end,
+    [fun () -> reconnect_subtest(?CLIENT_TCP) end]}.
 
 shackle_reconnect_udp_test_() ->
     {setup,
         fun () ->
             setup(),
-            shackle_pool:start(?POOL_NAME, ?CLIENT_UDP, [
-                {port, ?PORT},
-                {protocol, shackle_udp},
-                {reconnect, true},
-                {reconnect_time_min, 1},
-                {socket_options, [binary]
-            }], [{pool_size, 1}])
+            ?CLIENT_UDP:start()
         end,
-        fun (_) -> cleanup_tcp() end,
-    [fun reconnect_udp_subtest/0]}.
+        fun (_) -> cleanup(?CLIENT_UDP) end,
+    [fun () -> reconnect_subtest(?CLIENT_UDP) end]}.
 
 shackle_round_robin_tcp_test_() ->
     {setup,
-        fun () -> setup_tcp([
-            {pool_strategy, round_robin}
-        ]) end,
-        fun (_) -> cleanup_tcp() end,
+        fun () ->
+            setup(?CLIENT_TCP, [
+                {pool_strategy, round_robin}
+            ]) end,
+        fun (_) -> cleanup(?CLIENT_TCP) end,
     {inparallel, [
-        fun add_tcp_subtest/0,
-        fun multiply_tcp_subtest/0
+        fun () -> add_subtest(?CLIENT_TCP) end,
+        fun () -> multiply_subtest(?CLIENT_TCP) end
     ]}}.
 
 shackle_round_robin_udp_test_() ->
     {setup,
-        fun () -> setup_udp([
-            {pool_strategy, round_robin}
-        ]) end,
-        fun (_) -> cleanup_udp() end,
+        fun () ->
+            setup(?CLIENT_UDP, [
+                {pool_strategy, round_robin}
+            ])
+        end,
+        fun (_) -> cleanup(?CLIENT_UDP) end,
     {inparallel, [
-        fun add_udp_subtest/0,
-        fun multiply_udp_subtest/0
+        fun () -> add_subtest(?CLIENT_UDP) end,
+        fun () -> multiply_subtest(?CLIENT_UDP) end
     ]}}.
 
 %% tests
-add_ssl_subtest() ->
-    [assert_random_add(?CLIENT_SSL) || _ <- lists:seq(1, ?N)].
+add_subtest(Client) ->
+    [assert_random_add(Client) || _ <- lists:seq(1, ?N)].
 
-add_tcp_subtest() ->
-    [assert_random_add(?CLIENT_TCP) || _ <- lists:seq(1, ?N)].
+app_stop_start_subtest() ->
+    ?assertEqual({error, no_socket}, arithmetic_tcp_client:add(1, 1)),
+    ok = arithmetic_tcp_server:start(),
+    timer:sleep(100),
+    ?assertEqual(2, arithmetic_tcp_client:add(1, 1)),
 
-add_udp_subtest() ->
-    [assert_random_add(?CLIENT_UDP) || _ <- lists:seq(1, ?N)].
+    shackle_app:stop(),
+    timer:sleep(100),
+    shackle_app:start(),
+
+    arithmetic_tcp_client:start(),
+    timer:sleep(100),
+    ?assertEqual(2, arithmetic_tcp_client:add(1, 1)).
 
 backlog_full_subtest() ->
     Pid = self(),
@@ -167,71 +169,24 @@ backlog_full_subtest() ->
         (_) -> false
     end, receive_loop(20))).
 
-multiply_ssl_subtest() ->
-    [assert_random_multiply(?CLIENT_SSL) || _ <- lists:seq(1, ?N)].
-
-multiply_tcp_subtest() ->
-    [assert_random_multiply(?CLIENT_TCP) || _ <- lists:seq(1, ?N)].
-
-multiply_udp_subtest() ->
-    [assert_random_multiply(?CLIENT_UDP) || _ <- lists:seq(1, ?N)].
-
-reconnect_ssl_subtest() ->
-    ?assertEqual({error, no_socket}, arithmetic_ssl_client:add(1, 1)),
-    ok = arithmetic_ssl_server:start(),
-    timer:sleep(100),
-    ?assertEqual(2, arithmetic_ssl_client:add(1, 1)),
-    ok = arithmetic_ssl_server:stop(),
-    timer:sleep(100),
-    ?assertEqual({error, no_socket}, arithmetic_ssl_client:add(1, 1)),
-    ok = arithmetic_ssl_server:start(),
-    timer:sleep(100),
-    ?assertEqual(2, arithmetic_ssl_client:add(1, 1)).
-
-reconnect_tcp_subtest() ->
-    ?assertEqual({error, no_socket}, arithmetic_tcp_client:add(1, 1)),
-    ok = arithmetic_tcp_server:start(),
-    timer:sleep(100),
-    ?assertEqual(2, arithmetic_tcp_client:add(1, 1)),
-    ok = arithmetic_tcp_server:stop(),
-    timer:sleep(100),
-    ?assertEqual({error, no_socket}, arithmetic_tcp_client:add(1, 1)),
-    ok = arithmetic_tcp_server:start(),
-    timer:sleep(100),
+call_crash_subtest() ->
+    ?assertEqual({error, client_crash}, arithmetic_tcp_client:add(a, b)),
     ?assertEqual(2, arithmetic_tcp_client:add(1, 1)).
 
-app_stop_start_tcp_subtest() ->
-    ?assertEqual({error, no_socket}, arithmetic_tcp_client:add(1, 1)),
-    ok = arithmetic_tcp_server:start(),
-    timer:sleep(100),
-    ?assertEqual(2, arithmetic_tcp_client:add(1, 1)),
+multiply_subtest(Client) ->
+    [assert_random_multiply(Client) || _ <- lists:seq(1, ?N)].
 
-    shackle_app:stop(),
-    timer:sleep(200),
-    shackle_app:start(),
-
-    shackle_pool:start(?POOL_NAME, ?CLIENT_TCP, [
-        {port, ?PORT},
-        {protocol, shackle_tcp},
-        {reconnect, true},
-        {reconnect_time_min, 1},
-        {socket_options, [binary, {packet, raw}]}
-    ], [{pool_size, 1}]),
-
+reconnect_subtest(Client) ->
+    Server = server(Client),
+    ?assertEqual({error, no_socket}, Client:add(1, 1)),
+    ok = Server:start(),
     timer:sleep(100),
-    ?assertEqual(2, arithmetic_tcp_client:add(1, 1)).
-
-reconnect_udp_subtest() ->
-    ?assertEqual({error, no_socket}, arithmetic_udp_client:add(1, 1)),
-    ok = arithmetic_udp_server:start(),
+    ?assertEqual(2, Client:add(1, 1)),
+    ok = Server:stop(),
+    {error, _} = Client:add(1, 1), % no_socket (ssl, tcp) or timeout (udp)
+    ok = Server:start(),
     timer:sleep(100),
-    ?assertEqual(2, arithmetic_udp_client:add(1, 1)),
-    ok = arithmetic_udp_server:stop(),
-    timer:sleep(100),
-    ?assertEqual({error, timeout}, arithmetic_udp_client:add(1, 1)),
-    ok = arithmetic_udp_server:start(),
-    timer:sleep(100),
-    ?assertEqual(2, arithmetic_udp_client:add(1, 1)).
+    ?assertEqual(2, Client:add(1, 1)).
 
 %% utils
 assert_random_add(Client) ->
@@ -247,19 +202,10 @@ assert_random_multiply(Client) ->
 cleanup() ->
     shackle_app:stop().
 
-cleanup_ssl() ->
-    arithmetic_ssl_client:stop(),
-    arithmetic_ssl_server:stop(),
-    cleanup().
-
-cleanup_tcp() ->
-    arithmetic_tcp_client:stop(),
-    arithmetic_tcp_server:stop(),
-    cleanup().
-
-cleanup_udp() ->
-    arithmetic_udp_client:stop(),
-    arithmetic_udp_server:stop(),
+cleanup(Client) ->
+    Client:stop(),
+    Server = server(Client),
+    Server:stop(),
     cleanup().
 
 rand() ->
@@ -273,44 +219,20 @@ receive_loop(N) ->
             [X | receive_loop(N - 1)]
     end.
 
+server(?CLIENT_SSL) ->
+    arithmetic_ssl_server;
+server(?CLIENT_TCP) ->
+    arithmetic_tcp_server;
+server(?CLIENT_UDP) ->
+    arithmetic_udp_server.
+
 setup() ->
     error_logger:tty(false),
     shackle_app:start().
 
-setup_ssl(Options) ->
+setup(Client, Options) ->
     setup(),
-    arithmetic_ssl_server:start(),
-    shackle_pool:start(?POOL_NAME, ?CLIENT_SSL, [
-        {port, ?PORT},
-        {protocol, shackle_ssl},
-        {reconnect, true},
-        {socket_options, [
-            binary,
-            {packet, raw}
-        ]}
-    ], Options).
-
-setup_tcp(Options) ->
-    setup(),
-    arithmetic_tcp_server:start(),
-    shackle_pool:start(?POOL_NAME, ?CLIENT_TCP, [
-        {port, ?PORT},
-        {protocol, shackle_tcp},
-        {reconnect, true},
-        {socket_options, [
-            binary,
-            {packet, raw}
-        ]}
-    ], Options).
-
-setup_udp(Options) ->
-    setup(),
-    arithmetic_udp_server:start(),
-    shackle_pool:start(?POOL_NAME, ?CLIENT_UDP, [
-        {port, ?PORT},
-        {protocol, shackle_udp},
-        {reconnect, true},
-        {socket_options, [
-            binary
-        ]}
-    ], Options).
+    Server = server(Client),
+    Server:start(),
+    timer:sleep(100),
+    Client:start(Options).


### PR DESCRIPTION
Performance impact of wrapping all client calls in `try/catch` seems to be negligible.