### PR TITLE
Add optional handle_timeout callback

### DIFF
--- a/src/shackle_client.erl
+++ b/src/shackle_client.erl
@@ -16,5 +16,9 @@
     {ok, [Response :: response()], State :: term()} |
     {error,  Reason :: term(), State :: term()}.
 
+-callback handle_timeout(RequestId :: external_request_id(), State :: term()) ->
+    {ok, [Response :: response()], State :: term()} |
+    {error,  Reason :: term(), State :: term()}.
+
 -callback terminate(State :: term()) ->
     ok.

--- a/src/shackle_client.erl
+++ b/src/shackle_client.erl
@@ -1,6 +1,8 @@
 -module(shackle_client).
 -include("shackle_internal.hrl").
 
+-optional_callbacks([handle_timeout/2]).
+
 -callback init(Options :: term()) ->
     {ok, State :: term()} |
     {error, Reason :: term()}.
@@ -17,7 +19,7 @@
     {error,  Reason :: term(), State :: term()}.
 
 -callback handle_timeout(RequestId :: external_request_id(), State :: term()) ->
-    {ok, [Response :: response()], State :: term()} |
+    {ok, Response :: response(), State :: term()} |
     {error,  Reason :: term(), State :: term()}.
 
 -callback terminate(State :: term()) ->

--- a/src/shackle_ssl_server.erl
+++ b/src/shackle_ssl_server.erl
@@ -132,16 +132,38 @@ handle_msg({ssl, Socket, Data}, {#state {
             close(State, ClientState)
     end;
 handle_msg({timeout, ExtRequestId}, {#state {
-        name = Name
+        client = Client,
+        name = Name,
+        pool_name = PoolName,
+        socket = Socket
     } = State, ClientState}) ->
 
-    case shackle_queue:remove(Name, ExtRequestId) of
-        {ok, Cast, _TimerRef} ->
-            ?SERVER_UTILS:reply(Name, {error, timeout}, Cast);
-        {error, not_found} ->
-            ok
-    end,
-    {ok, {State, ClientState}};
+    case erlang:function_exported(Client, handle_timeout, 2) of
+        true ->
+            try Client:handle_timeout(ExtRequestId, ClientState) of
+                {ok, Reply, ClientState2} ->
+                    ?SERVER_UTILS:process_responses([Reply], Name),
+                    {ok, {State, ClientState2}};
+                {error, Reason, ClientState2} ->
+                    ?WARN(PoolName, "handle_timeout error: ~p", [Reason]),
+                    ssl:close(Socket),
+                    close(State, ClientState2)
+            catch
+                ?EXCEPTION(E, R, Stacktrace) ->
+                    ?WARN(PoolName, "handle_timeout error: ~p:~p~n~p~n",
+                        [E, R, ?GET_STACK(Stacktrace)]),
+                    ssl:close(Socket),
+                    close(State, ClientState)
+            end;
+        false ->
+            case shackle_queue:remove(Name, ExtRequestId) of
+                {ok, Cast, _TimerRef} ->
+                    ?SERVER_UTILS:reply(Name, {error, timeout}, Cast);
+                {error, not_found} ->
+                    ok
+            end,
+            {ok, {State, ClientState}}
+    end;
 handle_msg({ssl_closed, Socket}, {#state {
         socket = Socket,
         pool_name = PoolName

--- a/test/arithmetic_protocol.erl
+++ b/test/arithmetic_protocol.erl
@@ -11,7 +11,7 @@
 
 -define(MAX_REQUEST_ID, 4294967296).
 
--type int() :: 9..4294967295.
+-type int() :: 0..4294967295.
 -type operation() :: add | multiply.
 -type tiny_int() :: 0..255.
 
@@ -49,6 +49,10 @@ parse_replies(Buffer, Acc) ->
 
 parse_requests(<<"INIT", Rest/binary>>, Acc) ->
     parse_requests(Rest, [<<"OK">> | Acc]);
+parse_requests(<<ReqId:32/integer, 1, 255, 255, Rest/binary>>, Acc) ->
+    % special case to test timeouts add(255, 255)
+    timer:sleep(1000),
+    parse_requests(Rest, [<<ReqId:32/integer, 510:16/integer>> | Acc]);
 parse_requests(<<ReqId:32/integer, 1, A:8/integer, B:8/integer,
     Rest/binary>>, Acc) ->
 

--- a/test/arithmetic_ssl_client.erl
+++ b/test/arithmetic_ssl_client.erl
@@ -16,6 +16,7 @@
     setup/2,
     handle_request/2,
     handle_data/2,
+    handle_timeout/2,
     terminate/1
 ]).
 
@@ -96,6 +97,9 @@ handle_data(Data, #state {
     {ok, Replies, State#state {
         buffer = Buffer2
     }}.
+
+handle_timeout(RequestId, State) ->
+    {ok, {RequestId, {error, timeout_handled}}, State}.
 
 handle_request({Operation, A, B}, #state {
         request_counter = RequestCounter

--- a/test/arithmetic_tcp_client.erl
+++ b/test/arithmetic_tcp_client.erl
@@ -16,6 +16,7 @@
     setup/2,
     handle_request/2,
     handle_data/2,
+    handle_timeout/2,
     terminate/1
 ]).
 
@@ -95,6 +96,9 @@ handle_data(Data, #state {
     {ok, Replies, State#state {
         buffer = Buffer2
     }}.
+
+handle_timeout(RequestId, State) ->
+    {ok, {RequestId, {error, timeout_handled}}, State}.
 
 handle_request({Operation, A, B}, #state {
         request_counter = RequestCounter

--- a/test/arithmetic_udp_client.erl
+++ b/test/arithmetic_udp_client.erl
@@ -16,6 +16,7 @@
     setup/2,
     handle_request/2,
     handle_data/2,
+    handle_timeout/2,
     terminate/1
 ]).
 
@@ -95,6 +96,9 @@ handle_data(Data, #state {
     {ok, Replies, State#state {
         buffer = Buffer2
     }}.
+
+handle_timeout(RequestId, State) ->
+    {ok, [{RequestId, timeout_handled}], State}.
 
 handle_request({Operation, A, B}, #state {
         request_counter = RequestCounter

--- a/test/arithmetic_udp_client.erl
+++ b/test/arithmetic_udp_client.erl
@@ -98,7 +98,7 @@ handle_data(Data, #state {
     }}.
 
 handle_timeout(RequestId, State) ->
-    {ok, [{RequestId, timeout_handled}], State}.
+    {ok, {RequestId, {error, timeout_handled}}, State}.
 
 handle_request({Operation, A, B}, #state {
         request_counter = RequestCounter

--- a/test/shackle_tests.erl
+++ b/test/shackle_tests.erl
@@ -183,7 +183,11 @@ reconnect_subtest(Client) ->
     timer:sleep(100),
     ?assertEqual(2, Client:add(1, 1)),
     ok = Server:stop(),
-    {error, _} = Client:add(1, 1), % no_socket (ssl, tcp) or timeout (udp)
+    Result = Client:add(1, 1), % no_socket (ssl, tcp) or timeout (udp)
+    case Client of
+        ?CLIENT_UDP -> timeout_handled = Result;
+        _ -> {error, _} = Result
+    end,
     ok = Server:start(),
     timer:sleep(100),
     ?assertEqual(2, Client:add(1, 1)).

--- a/test/shackle_tests.erl
+++ b/test/shackle_tests.erl
@@ -139,6 +139,39 @@ shackle_round_robin_udp_test_() ->
         fun () -> multiply_subtest(?CLIENT_UDP) end
     ]}}.
 
+shackle_timeout_ssl_test_() ->
+    {setup,
+        fun () ->
+            setup(?CLIENT_SSL, [
+                {pool_size, 1},
+                {pool_strategy, random}
+            ])
+        end,
+        fun (_) -> cleanup(?CLIENT_SSL) end,
+    [fun () -> timeout_subtest(?CLIENT_SSL) end]}.
+
+shackle_timeout_tcp_test_() ->
+    {setup,
+        fun () ->
+            setup(?CLIENT_TCP, [
+                {pool_size, 1},
+                {pool_strategy, random}
+            ])
+        end,
+        fun (_) -> cleanup(?CLIENT_TCP) end,
+    [fun () -> timeout_subtest(?CLIENT_TCP) end]}.
+
+shackle_timeout_udp_test_() ->
+    {setup,
+        fun () ->
+            setup(?CLIENT_UDP, [
+                {pool_size, 1},
+                {pool_strategy, random}
+            ])
+        end,
+        fun (_) -> cleanup(?CLIENT_UDP) end,
+    [fun () -> timeout_subtest(?CLIENT_UDP) end]}.
+
 %% tests
 add_subtest(Client) ->
     [assert_random_add(Client) || _ <- lists:seq(1, ?N)].
@@ -183,14 +216,13 @@ reconnect_subtest(Client) ->
     timer:sleep(100),
     ?assertEqual(2, Client:add(1, 1)),
     ok = Server:stop(),
-    Result = Client:add(1, 1), % no_socket (ssl, tcp) or timeout (udp)
-    case Client of
-        ?CLIENT_UDP -> timeout_handled = Result;
-        _ -> {error, _} = Result
-    end,
+    {error, _} = Client:add(1, 1),
     ok = Server:start(),
     timer:sleep(100),
     ?assertEqual(2, Client:add(1, 1)).
+
+timeout_subtest(Client) ->
+    ?assertEqual({error, timeout_handled}, Client:add(255, 255)).
 
 %% utils
 assert_random_add(Client) ->
@@ -213,7 +245,7 @@ cleanup(Client) ->
     cleanup().
 
 rand() ->
-    shackle_utils:random(255).
+    shackle_utils:random(254).
 
 receive_loop(0) ->
     [];


### PR DESCRIPTION
This adds a `handle_timeout/2` callback to the shackle behavior which gives the client a chance to do certain things in case of timeout.

A use case for this could be that the client may want to accumulate response packets and send them as a whole. When timeout happens the client would flush out whatever it has. This additional callback would be helpful in that case.

If the callback is not defined by the client shackle will still send `{error, timeout}` message to the client.