### PR TITLE
isolate bad workers when dispatch traffic 

### DIFF
--- a/include/shackle.hrl
+++ b/include/shackle.hrl
@@ -11,7 +11,15 @@
     backlog_size  :: backlog_size(),
     client        :: client(),
     pool_size     :: pool_size(),
-    pool_strategy :: pool_strategy()
+    pool_strategy :: pool_strategy(),
+    %% the percentage of failed worker which will trigger pool_failure_callback_fn
+    %% 0 mean any worker failure will trigger that callback.
+    pool_failure_threshold_percentage = 0.0 :: float(),
+    %% the percentage of failed worker which will trigger pool_recover_callback_fn
+    %% 0 mean any worker failure will NOT trigger that callback.
+    pool_recover_threshold_percentage = 0.0 :: float(),
+    pool_failure_callback_fn :: fun(),
+    pool_recover_callback_fn :: fun()
 }).
 
 -record(reconnect_state, {

--- a/include/shackle_internal.hrl
+++ b/include/shackle_internal.hrl
@@ -15,6 +15,7 @@
 -define(ETS_TABLE_BACKLOG, shackle_backlog).
 -define(ETS_TABLE_POOL_INDEX, shackle_pool_index).
 -define(ETS_TABLE_QUEUE, shackle_queue).
+-define(ETS_TABLE_POOL_BAD_WORKER_NUMBERS, shackle_pool_bad_worker_number).
 
 %% compatibility
 -ifdef(OTP_RELEASE). %% this implies 21 or higher

--- a/src/shackle_pool.erl
+++ b/src/shackle_pool.erl
@@ -12,6 +12,10 @@
     stop/1
 ]).
 
+-export([
+    disable_worker/2,
+    enable_worker/2
+]).
 %% internal
 -export([
     init/0,
@@ -47,10 +51,7 @@ start(Name, Client, ClientOptions, Options) ->
 
 stop(Name) ->
     case options(Name) of
-        {ok, #pool_options {
-                pool_size = PoolSize
-            } = OptionsRec} ->
-
+        {ok, #pool_options{pool_size = PoolSize} = OptionsRec} ->
             stop_children(server_names(Name, PoolSize)),
             cleanup(Name, OptionsRec),
             ok;
@@ -68,6 +69,11 @@ init() ->
         public,
         {write_concurrency, true}
     ]),
+    ets:new(?ETS_TABLE_POOL_BAD_WORKERS, [
+        named_table,
+        public,
+        {write_concurrency, true}
+    ]),
     foil:new(?MODULE),
     foil:load(?MODULE).
 
@@ -76,21 +82,25 @@ init() ->
 
 server(Name) ->
     case options(Name) of
-        {ok, #pool_options {
-                backlog_size = BacklogSize,
-                client = Client,
-                pool_size = PoolSize,
-                pool_strategy = PoolStrategy
-            }} ->
-
-            ServerIndex = server_index(Name, PoolSize, PoolStrategy),
-            Key = {Name, ServerIndex},
-            {ok, Server} = shackle_pool_foil:lookup(Key),
-            case shackle_backlog:check(Server, BacklogSize) of
-                true ->
-                    {ok, Client, Server};
-                false ->
-                    {error, backlog_full}
+        {ok, #pool_options{
+            backlog_size = BacklogSize,
+            client = Client,
+            pool_size = PoolSize,
+            pool_strategy = PoolStrategy
+        }} ->
+            
+            case server_index(Name, PoolSize, PoolStrategy) of
+                {error, Reason} ->
+                    {error, Reason};
+                ServerIndex ->
+                    Key = {Name, ServerIndex},
+                    {ok, Server} = shackle_pool_foil:lookup(Key),
+                    case shackle_backlog:check(Server, BacklogSize) of
+                        true ->
+                            {ok, Client, Server};
+                        false ->
+                            {error, backlog_full}
+                    end
             end;
         {error, Reson} ->
             {error, Reson}
@@ -107,12 +117,12 @@ cleanup(Name, OptionsRec) ->
     cleanup_ets(Name, OptionsRec),
     cleanup_foil(Name, OptionsRec).
 
-cleanup_ets(Name, #pool_options {pool_strategy = round_robin}) ->
+cleanup_ets(Name, #pool_options{pool_strategy = round_robin}) ->
     ets:delete(?ETS_TABLE_POOL_INDEX, {Name, round_robin});
 cleanup_ets(_Name, _OptionsRec) ->
     ok.
 
-cleanup_foil(Name, #pool_options {pool_size = PoolSize}) ->
+cleanup_foil(Name, #pool_options{pool_size = PoolSize}) ->
     foil:delete(?MODULE, Name),
     [foil:delete(?MODULE, {Name, N}) || N <- lists:seq(1, PoolSize)],
     foil:load(?MODULE).
@@ -132,32 +142,50 @@ options_rec(Client, Options) ->
     BacklogSize = ?LOOKUP(backlog_size, Options, ?DEFAULT_BACKLOG_SIZE),
     PoolSize = ?LOOKUP(pool_size, Options, ?DEFAULT_POOL_SIZE),
     PoolStrategy = ?LOOKUP(pool_strategy, Options, ?DEFAULT_POOL_STRATEGY),
-
-    #pool_options {
+    
+    #pool_options{
         backlog_size = BacklogSize,
         client = Client,
         pool_size = PoolSize,
         pool_strategy = PoolStrategy
     }.
 
-server_index(_Name, PoolSize, random) ->
-    shackle_utils:random(PoolSize);
-server_index(Name, PoolSize, round_robin) ->
+server_index(Name, PoolSize, Stratege) ->
+    server_index(Name, PoolSize, Stratege, 1).
+server_index(Name, PoolSize, _Stratege, N) when N > (0.5 * PoolSize) ->
+    %% too many retires and cannot find a live worker. something is wrong with this worker pool
+    %% consider disabling it.
+    shackle_utils:warning_msg(Name, "Cannot find a live worker after many retries, consider to disable this pool, tried ~p times. ", [N]),
+    {error, no_worker};
+
+server_index(Name, PoolSize, random, N) ->
+    ServerId = shackle_utils:random(PoolSize),
+    check_server_id(Name, PoolSize, ServerId, random, N + 1);
+server_index(Name, PoolSize, round_robin, N) ->
     UpdateOps = [{2, 1, PoolSize, 1}],
     Key = {Name, round_robin},
     [ServerId] = ets:update_counter(?ETS_TABLE_POOL_INDEX, Key, UpdateOps),
-    ServerId.
+    check_server_id(Name, PoolSize, ServerId, round_robin, N + 1).
+
+check_server_id(Name, PoolSize, ServerId, Stretegy, N) ->
+    case is_worker_disabled(Name, ServerId) of
+        true ->
+            shackle_utils:warning_msg(Name, "got a dead worker id ~p, try again", [ServerId]),
+            server_index(Name, PoolSize, Stretegy, N);
+        _ ->
+            ServerId
+    end.
 
 setup(Name, OptionsRec) ->
     setup_ets(Name, OptionsRec),
     setup_foil(Name, OptionsRec).
 
-setup_ets(Name, #pool_options {pool_strategy = round_robin}) ->
+setup_ets(Name, #pool_options{pool_strategy = round_robin}) ->
     ets:insert_new(?ETS_TABLE_POOL_INDEX, {{Name, round_robin}, 1});
 setup_ets(_Name, _OptionsRec) ->
     ok.
 
-setup_foil(Name, #pool_options {pool_size = PoolSize} = OptionsRec) ->
+setup_foil(Name, #pool_options{pool_size = PoolSize} = OptionsRec) ->
     foil:insert(?MODULE, Name, OptionsRec),
     [foil:insert(?MODULE, {Name, N}, server_name(Name, N)) ||
         N <- lists:seq(1, PoolSize)],
@@ -176,20 +204,23 @@ server_mod(shackle_tcp) ->
 server_mod(shackle_udp) ->
     shackle_udp_server.
 
-server_spec(ServerMod, ServerName, Name, Client, ClientOptions) ->
+server_spec(ServerMod, ServerName, Name, Client, ClientOptions, Index) ->
     StartFunc = {ServerMod, start_link,
-        [ServerName, Name, Client, ClientOptions]},
+        [ServerName, Name, Client, ClientOptions, Index]},
     {ServerName, StartFunc, permanent, 5000, worker, [ServerMod]}.
 
-start_children(Name, Client, ClientOptions, #pool_options {
-        pool_size = PoolSize
-    }) ->
-
+start_children(Name, Client, ClientOptions, #pool_options{
+    pool_size = PoolSize
+}) ->
+    
     Protocol = ?LOOKUP(protocol, ClientOptions, ?DEFAULT_PROTOCOL),
     ServerMod = server_mod(Protocol),
-    ServerNames = server_names(Name, PoolSize),
-    ServerSpecs = [server_spec(ServerMod, ServerName, Name,
-        Client, ClientOptions) || ServerName <- ServerNames],
+    ServerSpecs = [
+        begin
+            ServerName = server_name(Name, N),
+            server_spec(ServerMod, ServerName, Name,
+                Client, ClientOptions, N)
+        end || N <- lists:seq(1, PoolSize)],
     [supervisor:start_child(?SUPERVISOR, ServerSpec) ||
         ServerSpec <- ServerSpecs].
 
@@ -199,3 +230,12 @@ stop_children([ServerName | T]) ->
     supervisor:terminate_child(?SUPERVISOR, ServerName),
     supervisor:delete_child(?SUPERVISOR, ServerName),
     stop_children(T).
+
+disable_worker(PoolName, Index) ->
+    ets:insert(?ETS_TABLE_POOL_BAD_WORKERS, {{PoolName, Index}, true}).
+
+enable_worker(PoolName, Index) ->
+    ets:delete_object(?ETS_TABLE_POOL_BAD_WORKERS, {PoolName, Index}).
+
+is_worker_disabled(PoolName, Index) ->
+    ets:lookup(?ETS_TABLE_POOL_BAD_WORKERS, {PoolName, Index}) /= [].

--- a/src/shackle_ssl_server.erl
+++ b/src/shackle_ssl_server.erl
@@ -5,7 +5,7 @@
 -compile({inline_size, 512}).
 
 -export([
-    start_link/4
+    start_link/5
 ]).
 
 -behavior(metal).
@@ -26,18 +26,19 @@
     reconnect_state  :: undefined | reconnect_state(),
     socket           :: undefined | ssl:sslsocket(),
     socket_options   :: [ssl:connect_option()],
-    timer_ref        :: undefined | reference()
+    timer_ref        :: undefined | reference(),
+    worker_index     :: pos_integer()
 }).
 
--type init_opts() :: {pool_name(), client(), client_options()}.
+-type init_opts() :: {pool_name(), client(), client_options(), pos_integer()}.
 -type state() :: #state {}.
 
 %% public
--spec start_link(server_name(), pool_name(), client(), client_options()) ->
+-spec start_link(server_name(), pool_name(), client(), client_options(), pos_integer()) ->
     {ok, pid()}.
 
-start_link(Name, PoolName, Client, ClientOptions) ->
-    Args = {PoolName, Client, ClientOptions},
+start_link(Name, PoolName, Client, ClientOptions, Index) ->
+    Args = {PoolName, Client, ClientOptions, Index},
     metal:start_link(?MODULE, Name, Args).
 
 %% metal callbacks
@@ -45,7 +46,7 @@ start_link(Name, PoolName, Client, ClientOptions) ->
     no_return().
 
 init(Name, Parent, Opts) ->
-    {PoolName, Client, ClientOptions} = Opts,
+    {PoolName, Client, ClientOptions, Index} = Opts,
     self() ! ?MSG_CONNECT,
     ok = shackle_backlog:new(Name),
 
@@ -66,7 +67,8 @@ init(Name, Parent, Opts) ->
         pool_name = PoolName,
         port = Port,
         reconnect_state = ReconnectState,
-        socket_options = SocketOptions
+        socket_options = SocketOptions,
+        worker_index = Index
     }, undefined}}.
 
 -spec handle_msg(term(), {state(), client_state()}) ->
@@ -186,7 +188,8 @@ handle_msg(?MSG_CONNECT, {#state {
         pool_name = PoolName,
         port = Port,
         reconnect_state = ReconnectState,
-        socket_options = SocketOptions
+        socket_options = SocketOptions,
+        worker_index = Index
     } = State, ClientState}) ->
 
     case connect(PoolName, Ip, Port, SocketOptions) of
@@ -195,7 +198,7 @@ handle_msg(?MSG_CONNECT, {#state {
                 {ok, ClientState2} ->
                     ReconnectState2 =
                         ?SERVER_UTILS:reconnect_state_reset(ReconnectState),
-
+                    shackle_pool:worker_up(PoolName, Index),
                     {ok, {State#state {
                         reconnect_state = ReconnectState2,
                         socket = Socket
@@ -236,8 +239,9 @@ terminate(_Reason, {#state {
     ok.
 
 %% private
-close(#state {name = Name} = State, ClientState) ->
+close(#state {name = Name, pool_name = PoolName, worker_index = Index} = State, ClientState) ->
     ?SERVER_UTILS:reply_all(Name, {error, socket_closed}),
+    shackle_pool:worker_down(PoolName, Index),
     reconnect(State, ClientState).
 
 connect(PoolName, Ip, Port, SocketOptions) ->


### PR DESCRIPTION
This PR fixed several problems for shackle:

- if a worker is down, then shackle shouldn't route any requests to that worker.
- if too many workers are down, then call back to marina pool to stop routing any traffics to this worker pool.
- if workers recovered, then callback to marina to resume requests to this pool.