### PR TITLE
Disable atomics on OTP 21.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -32,7 +32,7 @@
 
 {erl_opts, [
   debug_info,
-  {platform_define, "^21.2|^21.3|^22", 'ATOMICS'},
+  {platform_define, "^21.3|^22", 'ATOMICS'},
   {platform_define, "^18|^19|^2", 'ETS_TAKE'},
   {platform_define, "^18", 'UDP_HEADER_1'},
   {platform_define, "^19|^20|^21|^22.0", 'UDP_HEADER_2'}


### PR DESCRIPTION
While the persistent_term module was introduced in OTP 21.2,
persistent_term:get/2 was only added in OTP 21.3.

I can confirm this fixes an issue running tests locally with OTP 21.2

Fixes #103 