### PR TITLE
Fix UDP_HEADER_2 regex

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -35,7 +35,8 @@
   {platform_define, "^21.3|^22", 'ATOMICS'},
   {platform_define, "^18|^19|^2", 'ETS_TAKE'},
   {platform_define, "^18", 'UDP_HEADER_1'},
-  {platform_define, "^19|^20|^21|^22.0", 'UDP_HEADER_2'}
+  % exclude OTP-21.3.8.4+ and OTP-22.1+
+  {platform_define, "^19|^20|^21.((0..2)|3(.(1..7))?|3.8(.(1..3))?)|^22.0", 'UDP_HEADER_2'}
 ]}.
 
 {profiles, [


### PR DESCRIPTION
UDP changes have been back-ported into OTP-21.3.8.4+.