### PR TITLE
Switch connection closed msg level from warning to debug

### DIFF
--- a/include/shackle_internal.hrl
+++ b/include/shackle_internal.hrl
@@ -23,10 +23,13 @@
 -define(GET_STACK(Stacktrace), Stacktrace).
 
 -include_lib("kernel/include/logger.hrl").
+-define(DEBUG(PoolName, Format, Data), ?LOG_DEBUG("[~p] " ++ Format, [PoolName | Data])).
 -define(WARN(PoolName, Format, Data), ?LOG_WARNING("[~p] " ++ Format, [PoolName | Data])).
 -else.
 -define(EXCEPTION(Class, Reason, _), Class:Reason).
 -define(GET_STACK(_), erlang:get_stacktrace()).
 
+% HACK: error_logger doesn't support DEBUG level so we use INFO instead
+-define(DEBUG(PoolName, Format, Data), shackle_utils:info_msg(PoolName, Format, Data)).
 -define(WARN(PoolName, Format, Data), shackle_utils:warning_msg(PoolName, Format, Data)).
 -endif.

--- a/src/shackle_server.erl
+++ b/src/shackle_server.erl
@@ -313,7 +313,7 @@ handle_msg_close(Socket, #state {
         pool_name = PoolName
     } = State, ClientState) ->
 
-    ?WARN(PoolName, "connection closed", []),
+    ?DEBUG(PoolName, "connection closed", []),
     close(State, ClientState);
 handle_msg_close(_Socket, State, ClientState) ->
     {ok, {State, ClientState}}.

--- a/src/shackle_utils.erl
+++ b/src/shackle_utils.erl
@@ -7,6 +7,7 @@
 %% public
 -export([
     ets_options/0,
+    info_msg/3,
     lookup/3,
     random/1,
     random_element/1,
@@ -36,6 +37,11 @@ ets_options() -> [
 
 -endif.
 
+-spec info_msg(pool_name(), string(), [term()]) ->
+    ok.
+
+info_msg(Pool, Format, Data) ->
+    error_logger:info_msg("[~p] " ++ Format, [Pool | Data]).
 
 -spec lookup(atom(), [{atom(), term()}], term()) ->
     term().


### PR DESCRIPTION
Connection closed message could spam logs for clients that don't support keep-alive. To fix the issue we moved the message to debug level. Closes https://github.com/lpgauth/shackle/issues/124.