### PR TITLE
Handle iolists for shackle_telemetry:send/2

### DIFF
--- a/src/shackle_server.erl
+++ b/src/shackle_server.erl
@@ -115,7 +115,7 @@ handle_msg({Request, #cast {
         {ok, ExtRequestId, Data, ClientState2} ->
             case Protocol:send(Socket, Data) of
                 ok ->
-                    shackle_telemetry:send(Client, size(Data)),
+                    shackle_telemetry:send(Client, iolist_size(Data)),
                     case ExtRequestId of
                         undefined ->
                             reply(ok, Cast, State);


### PR DESCRIPTION
`erlang:size/1` doesn't work on iolists, which caused some tests to fail in buoy while trying out the latest commits in shackle. Using `erlang:iolist_size/1` fixes the issue.