### PR TITLE
More telemetry events

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,17 @@ shackle_pool:start(shackle_pool:name(), client(), client_options(), pool_options
 ```
 
 ## Telemetry
-Shackle integrates with the backend-agnostic [telemetry](https://hexdocs.pm/telemetry/) library. See `shackle_telemetry` for the list of telemetry events that shackle can emit.
+
+It is straightforward to integrate Shackle with the backend-agnostic [telemetry](https://hexdocs.pm/telemetry/) library.
+Because the calling convention in `shackle_hooks` closely resembles `telemetry:execute`, it is possible configure Shackle like so:
+
+```
+{shackle, [
+  {hooks, [
+    {metrics, {telemetry, execute}}
+  ]}
+]}
+```
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Because the calling convention in `shackle_hooks` closely resembles `telemetry:e
 ```
 {shackle, [
   {hooks, [
-    {metrics, {telemetry, execute}}
+    {events, {telemetry, execute}}
   ]}
 ]}
 ```

--- a/include/shackle.hrl
+++ b/include/shackle.hrl
@@ -4,7 +4,7 @@
     pid            :: undefined | pid(),
     request_id     :: shackle:request_id(),
     timeout        :: timeout(),
-    timestamp      :: erlang:timestamp()
+    timestamp      :: integer()
 }).
 
 -record(reconnect_state, {

--- a/rebar.config
+++ b/rebar.config
@@ -7,8 +7,7 @@
 {deps, [
   {foil, "0.1.3"},
   {granderl, {git, "https://github.com/tokenrove/granderl.git", {ref, "baafd1bc825cb1fc022760eae913f774fa6af91b"}}},
-  {metal, "0.1.1"},
-  {telemetry, "1.2.1"}
+  {metal, "0.1.1"}
 ]}.
 
 {dialyzer, [{plt_extra_apps, [public_key]}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -4,8 +4,7 @@
   {git,"https://github.com/tokenrove/granderl.git",
        {ref,"baafd1bc825cb1fc022760eae913f774fa6af91b"}},
   0},
- {<<"metal">>,{pkg,<<"metal">>,<<"0.1.1">>},0},
- {<<"telemetry">>,{pkg,<<"telemetry">>,<<"1.2.1">>},0}]}.
+ {<<"metal">>,{pkg,<<"metal">>,<<"0.1.1">>},0}]}.
 [
 {pkg_hash,[
  {<<"foil">>, <<"415835CA94A8D0A55AB3D334FE2D1A1DCF36E7A0F69789050765770B6BF5E6E9">>},

--- a/src/shackle.app.src
+++ b/src/shackle.app.src
@@ -1,5 +1,5 @@
 {application, shackle, [
-  {applications, [kernel, stdlib, granderl, metal, foil, ssl, telemetry]},
+  {applications, [kernel, stdlib, granderl, metal, foil, ssl]},
   {description, "High-Performance Erlang Network Client Framework"},
   {env, []},
   {licenses, ["MIT"]},

--- a/src/shackle.erl
+++ b/src/shackle.erl
@@ -78,7 +78,7 @@ cast(PoolName, Request, Pid) ->
     {ok, request_id()} | {error, atom()}.
 
 cast(PoolName, Request, Pid, Timeout) ->
-    Timestamp = os:timestamp(),
+    Timestamp = erlang:monotonic_time(),
     Ref = make_ref(),
     case shackle_pool:server(PoolName) of
         {ok, Client, Server} ->

--- a/src/shackle_events.erl
+++ b/src/shackle_events.erl
@@ -20,86 +20,129 @@
     timeout/2
 ]).
 
+-define(EVENT(Block),
+    case shackle_hooks:handler() of
+        {M, F} ->
+            {EventName, Measurements, Metadata} = Block,
+            M:F(EventName, Measurements, Metadata);
+        _ ->
+            ok
+    end
+).
+
 -spec backlog_full(shackle:client()) -> ok.
 backlog_full(Client) ->
+?EVENT(begin
     Measurements = #{count => 1},
     Metadata = #{client => Client},
-    shackle_hooks:event([shackle, backlog_full], Measurements, Metadata).
+    {[shackle, backlog_full], Measurements, Metadata}
+end).
 
--spec connected(shackle:client(), shackle_pool:name(), non_neg_integer()) -> ok.
-connected(Client, PoolName, Duration) ->
-    Measurements = #{count => 1, duration => Duration},
+-spec connected(shackle:client(), shackle_pool:name(), integer()) -> ok.
+connected(Client, PoolName, StartTime) ->
+?EVENT(begin
+    Measurements = #{count => 1, duration => duration_since(StartTime)},
     Metadata = #{client => Client, pool_name => PoolName},
-    shackle_hooks:event([shackle, connected], Measurements, Metadata).
+    {[shackle, connected], Measurements, Metadata}
+end).
 
 -spec connection_error(shackle:client(), shackle_pool:name(), any()) -> ok.
 connection_error(Client, PoolName, Reason) ->
+?EVENT(begin
     Measurements = #{count => 1},
     Metadata = #{client => Client, pool_name => PoolName, reason => Reason},
-    shackle_hooks:event([shackle, connection_error], Measurements, Metadata).
+    {[shackle, connection_error], Measurements, Metadata}
+end).
 
 -spec disabled(shackle:client()) -> ok.
 disabled(Client) ->
+?EVENT(begin
     Measurements = #{count => 1},
     Metadata = #{client => Client},
-    shackle_hooks:event([shackle, disabled], Measurements, Metadata).
+    {[shackle, disabled], Measurements, Metadata}
+end).
 
 -spec found(shackle:client()) -> ok.
 found(Client) ->
+?EVENT(begin
     Measurements = #{count => 1},
     Metadata = #{client => Client},
-    shackle_hooks:event([shackle, found], Measurements, Metadata).
+    {[shackle, found], Measurements, Metadata}
+end).
 
 -spec handle_timeout(shackle:client()) -> ok.
 handle_timeout(Client) ->
+?EVENT(begin
     Measurements = #{count => 1},
     Metadata = #{client => Client},
-    shackle_hooks:event([shackle, handle_timeout], Measurements, Metadata).
+    {[shackle, handle_timeout], Measurements, Metadata}
+end).
 
 -spec no_server(shackle:client()) -> ok.
 no_server(Client) ->
+?EVENT(begin
     Measurements = #{count => 1},
     Metadata = #{client => Client},
-    shackle_hooks:event([shackle, no_server], Measurements, Metadata).
+    {[shackle, no_server], Measurements, Metadata}
+end).
 
 -spec not_found(shackle:client()) -> ok.
 not_found(Client) ->
+?EVENT(begin
     Measurements = #{count => 1},
     Metadata = #{client => Client},
-    shackle_hooks:event([shackle, not_found], Measurements, Metadata).
+    {[shackle, not_found], Measurements, Metadata}
+end).
 
 -spec queued_time(shackle:client(), non_neg_integer()) -> ok.
-queued_time(Client, Duration) ->
-    Measurements = #{duration => Duration},
+queued_time(Client, StartTime) ->
+?EVENT(begin
+    Measurements = #{duration => duration_since(StartTime)},
     Metadata = #{client => Client},
-    shackle_hooks:event([shackle, queued_time], Measurements, Metadata).
+    {[shackle, queued_time], Measurements, Metadata}
+end).
 
--spec recv(shackle:client(), non_neg_integer()) -> ok.
-recv(Client, NBytes) ->
-    Measurements = #{count => 1, bytes => NBytes},
+-spec recv(shackle:client(), iodata()) -> ok.
+recv(Client, Data) ->
+?EVENT(begin
+    Measurements = #{count => 1, bytes => iolist_size(Data)},
     Metadata = #{client => Client},
-    shackle_hooks:event([shackle, recv], Measurements, Metadata).
+    {[shackle, recv], Measurements, Metadata}
+end).
 
 -spec replies(shackle:client()) -> ok.
 replies(Client) ->
+?EVENT(begin
     Measurements = #{count => 1},
     Metadata = #{client => Client},
-    shackle_hooks:event([shackle, replies], Measurements, Metadata).
+    {[shackle, replies], Measurements, Metadata}
+end).
 
--spec reply(shackle:client(), term(), term(), non_neg_integer()) -> ok.
-reply(Client, Request, Response, Duration) ->
-    Measurements = #{duration => Duration},
+-spec reply(shackle:client(), term(), term(), integer()) -> ok.
+reply(Client, Request, Response, Timestamp) ->
+?EVENT(begin
+    Measurements = #{duration => duration_since(Timestamp)},
     Metadata = #{client => Client, request => Request, response => Response},
-    shackle_hooks:event([shackle, reply], Measurements, Metadata).
+    {[shackle, reply], Measurements, Metadata}
+end).
 
--spec send(shackle:client(), non_neg_integer()) -> ok.
-send(Client, NBytes) ->
-    Measurements = #{count => 1, bytes => NBytes},
+-spec send(shackle:client(), iodata()) -> ok.
+send(Client, Data) ->
+?EVENT(begin
+    Measurements = #{count => 1, bytes => iolist_size(Data)},
     Metadata = #{client => Client},
-    shackle_hooks:event([shackle, send], Measurements, Metadata).
+    {[shackle, send], Measurements, Metadata}
+end).
 
 -spec timeout(shackle:client(), term()) -> ok.
 timeout(Client, Request) ->
+?EVENT(begin
     Measurements = #{count => 1},
     Metadata = #{client => Client, request => Request},
-    shackle_hooks:event([shackle, timeout], Measurements, Metadata).
+    {[shackle, timeout], Measurements, Metadata}
+end).
+
+%% private
+
+duration_since(Timestamp) ->
+    erlang:monotonic_time() - Timestamp.

--- a/src/shackle_events.erl
+++ b/src/shackle_events.erl
@@ -1,4 +1,4 @@
--module(shackle_telemetry).
+-module(shackle_events).
 
 -compile(inline).
 -compile({inline_size, 512}).

--- a/src/shackle_hooks.erl
+++ b/src/shackle_hooks.erl
@@ -1,7 +1,7 @@
 -module(shackle_hooks).
 -include("shackle_internal.hrl").
 
--dialyzer({nowarn_function, event/3}).
+-dialyzer({nowarn_function, handler/0}).
 -ignore_xref([
     {shackle_hooks_foil, lookup, 1}
 ]).
@@ -11,7 +11,7 @@
 
 -export([
     init/0,
-    event/3
+    handler/0
 ]).
 
 %% callbacks
@@ -36,13 +36,9 @@ init() ->
     foil:load(?MODULE),
     ok.
 
--spec event(event_name(), event_measurements(), event_metadata()) ->
-    ok.
-
-event(EventName, Measurements, Metadata) ->
+-spec handler() -> {atom(), atom()} | undefined.
+handler() ->
     case shackle_hooks_foil:lookup(events) of
-        {ok, {M, F}} ->
-            M:F(EventName, Measurements, Metadata);
-        _ ->
-            ok
+        {ok, {M, F}} -> {M, F};
+        _ -> undefined
     end.

--- a/src/shackle_hooks.erl
+++ b/src/shackle_hooks.erl
@@ -30,9 +30,9 @@
 
 init() ->
     Hooks = ?GET_ENV(hooks, []),
-    Metrics = ?LOOKUP(metrics, Hooks, undefined),
+    Events = ?LOOKUP(events, Hooks, undefined),
     foil:new(?MODULE),
-    foil:insert(?MODULE, metrics, Metrics),
+    foil:insert(?MODULE, events, Events),
     foil:load(?MODULE),
     ok.
 
@@ -40,7 +40,7 @@ init() ->
     ok.
 
 event(EventName, Measurements, Metadata) ->
-    case shackle_hooks_foil:lookup(metrics) of
+    case shackle_hooks_foil:lookup(events) of
         {ok, {M, F}} ->
             M:F(EventName, Measurements, Metadata);
         _ ->

--- a/src/shackle_hooks.erl
+++ b/src/shackle_hooks.erl
@@ -1,0 +1,48 @@
+-module(shackle_hooks).
+-include("shackle_internal.hrl").
+
+-dialyzer({nowarn_function, event/3}).
+-ignore_xref([
+    {shackle_hooks_foil, lookup, 1}
+]).
+
+-compile(inline).
+-compile({inline_size, 512}).
+
+-export([
+    init/0,
+    event/3
+]).
+
+%% callbacks
+-optional_callbacks([event/3]).
+
+-type event_name() :: [atom(), ...].
+-type event_measurements() :: map().
+-type event_metadata() :: map().
+
+-callback event(event_name(), event_measurements(), event_metadata()) ->
+    ok.
+
+%% public
+-spec init() ->
+    ok.
+
+init() ->
+    Hooks = ?GET_ENV(hooks, []),
+    Metrics = ?LOOKUP(metrics, Hooks, undefined),
+    foil:new(?MODULE),
+    foil:insert(?MODULE, metrics, Metrics),
+    foil:load(?MODULE),
+    ok.
+
+-spec event(event_name(), event_measurements(), event_metadata()) ->
+    ok.
+
+event(EventName, Measurements, Metadata) ->
+    case shackle_hooks_foil:lookup(metrics) of
+        {ok, {M, F}} ->
+            M:F(EventName, Measurements, Metadata);
+        _ ->
+            ok
+    end.

--- a/src/shackle_pool.erl
+++ b/src/shackle_pool.erl
@@ -165,7 +165,7 @@ server(_Name, #pool_options {
         client = Client
     }, 0) ->
 
-    shackle_telemetry:no_server(Client),
+    shackle_events:no_server(Client),
     {error, no_server};
 server(Name, #pool_options {
         backlog_size = BacklogSize,
@@ -183,11 +183,11 @@ server(Name, #pool_options {
                 true ->
                     {ok, Client, ServerName};
                 false ->
-                    shackle_telemetry:backlog_full(Client),
+                    shackle_events:backlog_full(Client),
                     server(Name, Options, N - 1)
             end;
         false ->
-            shackle_telemetry:disabled(Client),
+            shackle_events:disabled(Client),
             server(Name, Options, N - 1)
     end.
 

--- a/src/shackle_queue.erl
+++ b/src/shackle_queue.erl
@@ -5,7 +5,7 @@
 
 %% internal
 -export([
-    add/5,
+    add/6,
     clear/2,
     delete/1,
     new/1,
@@ -14,16 +14,16 @@
 ]).
 
 %% internal
--spec add(shackle:table(), shackle_server:id(), shackle:external_request_id(), shackle:cast(), reference()) ->
+-spec add(shackle:table(), shackle_server:id(), shackle:external_request_id(), term(), shackle:cast(), reference()) ->
     ok.
 
-add(Table, ServerId, ExtRequestId, Cast, TimerRef) ->
-    Object = {{ServerId, ExtRequestId}, {Cast, TimerRef}},
+add(Table, ServerId, ExtRequestId, Request, Cast, TimerRef) ->
+    Object = {{ServerId, ExtRequestId}, {Cast, Request, TimerRef}},
     ets:insert(Table, Object),
     ok.
 
 -spec clear(shackle:table(), shackle_server:id()) ->
-    [{shackle:cast(), reference()}].
+    [{shackle:cast(), term(), reference()}].
 
 clear(Table, ServerId) ->
     Match = {{ServerId, '_'}, '_'},
@@ -31,7 +31,7 @@ clear(Table, ServerId) ->
         [] ->
             [];
         Objects ->
-            [{Cast, TimerRef} || {_, {Cast, TimerRef}} <- Objects]
+            [{Cast, Request, TimerRef} || {_, {Cast, Request, TimerRef}} <- Objects]
     end.
 
 -spec delete(shackle_pool:name()) ->
@@ -50,14 +50,14 @@ new(PoolName) ->
     ok.
 
 -spec remove(shackle:table(), shackle_server:id(), shackle:external_request_id()) ->
-    {ok, shackle:cast(), reference()} | {error, not_found}.
+    {ok, shackle:cast(), term(), reference()} | {error, not_found}.
 
 remove(Table, ServerId, ExtRequestId) ->
     case ets_take(Table, {ServerId, ExtRequestId}) of
         [] ->
             {error, not_found};
-        [{_, {Cast, TimerRef}}] ->
-            {ok, Cast, TimerRef}
+        [{_, {Cast, Request, TimerRef}}] ->
+            {ok, Cast, Request, TimerRef}
     end.
 
 %% private

--- a/src/shackle_server.erl
+++ b/src/shackle_server.erl
@@ -307,11 +307,14 @@ close(#state {id = Id} = State, ClientState) ->
     reconnect(State, ClientState).
 
 connect(Client, Protocol, Address, Port, SocketOptions, PoolName) ->
+    StartTime = os:timestamp(),
     case inet:getaddrs(Address, inet) of
         {ok, Ips} ->
             Ip = shackle_utils:random_element(Ips),
             case Protocol:connect(Ip, Port, SocketOptions) of
                 {ok, Socket} ->
+                    Diff = timer:now_diff(os:timestamp(), StartTime),
+                    shackle_telemetry:connected(Client, PoolName, Diff),
                     {ok, Socket};
                 {error, Reason} ->
                     shackle_telemetry:connection_error(Client, PoolName, Reason),

--- a/src/shackle_server.erl
+++ b/src/shackle_server.erl
@@ -386,7 +386,7 @@ process_responses([{ExtRequestId, Reply} | T], #state {
         {ok, #cast {timestamp = Timestamp} = Cast, Request, TimerRef} ->
             shackle_telemetry:found(Client),
             Diff = timer:now_diff(os:timestamp(), Timestamp),
-            shackle_telemetry:reply(Client, Request, Diff),
+            shackle_telemetry:reply(Client, Request, Reply, Diff),
             erlang:cancel_timer(TimerRef),
             reply(Reply, Cast, State);
         {error, not_found} ->

--- a/src/shackle_sup.erl
+++ b/src/shackle_sup.erl
@@ -23,6 +23,7 @@ start_link() ->
     {ok, {{one_for_one, 5, 10}, [supervisor:child_spec()]}}.
 
 init([]) ->
+    shackle_hooks:init(),
     shackle_pool:init(),
     shackle_status:init(),
 

--- a/src/shackle_telemetry.erl
+++ b/src/shackle_telemetry.erl
@@ -24,82 +24,82 @@
 backlog_full(Client) ->
     Measurements = #{count => 1},
     Metadata = #{client => Client},
-    telemetry:execute([shackle, backlog_full], Measurements, Metadata).
+    shackle_hooks:event([shackle, backlog_full], Measurements, Metadata).
 
 -spec connected(shackle:client(), shackle_pool:name(), non_neg_integer()) -> ok.
 connected(Client, PoolName, Duration) ->
     Measurements = #{count => 1, duration => Duration},
     Metadata = #{client => Client, pool_name => PoolName},
-    telemetry:execute([shackle, connected], Measurements, Metadata).
+    shackle_hooks:event([shackle, connected], Measurements, Metadata).
 
 -spec connection_error(shackle:client(), shackle_pool:name(), any()) -> ok.
 connection_error(Client, PoolName, Reason) ->
     Measurements = #{count => 1},
     Metadata = #{client => Client, pool_name => PoolName, reason => Reason},
-    telemetry:execute([shackle, connection_error], Measurements, Metadata).
+    shackle_hooks:event([shackle, connection_error], Measurements, Metadata).
 
 -spec disabled(shackle:client()) -> ok.
 disabled(Client) ->
     Measurements = #{count => 1},
     Metadata = #{client => Client},
-    telemetry:execute([shackle, disabled], Measurements, Metadata).
+    shackle_hooks:event([shackle, disabled], Measurements, Metadata).
 
 -spec found(shackle:client()) -> ok.
 found(Client) ->
     Measurements = #{count => 1},
     Metadata = #{client => Client},
-    telemetry:execute([shackle, found], Measurements, Metadata).
+    shackle_hooks:event([shackle, found], Measurements, Metadata).
 
 -spec handle_timeout(shackle:client()) -> ok.
 handle_timeout(Client) ->
     Measurements = #{count => 1},
     Metadata = #{client => Client},
-    telemetry:execute([shackle, handle_timeout], Measurements, Metadata).
+    shackle_hooks:event([shackle, handle_timeout], Measurements, Metadata).
 
 -spec no_server(shackle:client()) -> ok.
 no_server(Client) ->
     Measurements = #{count => 1},
     Metadata = #{client => Client},
-    telemetry:execute([shackle, no_server], Measurements, Metadata).
+    shackle_hooks:event([shackle, no_server], Measurements, Metadata).
 
 -spec not_found(shackle:client()) -> ok.
 not_found(Client) ->
     Measurements = #{count => 1},
     Metadata = #{client => Client},
-    telemetry:execute([shackle, not_found], Measurements, Metadata).
+    shackle_hooks:event([shackle, not_found], Measurements, Metadata).
 
 -spec queued_time(shackle:client(), non_neg_integer()) -> ok.
 queued_time(Client, Duration) ->
     Measurements = #{duration => Duration},
     Metadata = #{client => Client},
-    telemetry:execute([shackle, queued_time], Measurements, Metadata).
+    shackle_hooks:event([shackle, queued_time], Measurements, Metadata).
 
 -spec recv(shackle:client(), non_neg_integer()) -> ok.
 recv(Client, NBytes) ->
     Measurements = #{count => 1, bytes => NBytes},
     Metadata = #{client => Client},
-    telemetry:execute([shackle, recv], Measurements, Metadata).
+    shackle_hooks:event([shackle, recv], Measurements, Metadata).
 
 -spec replies(shackle:client()) -> ok.
 replies(Client) ->
     Measurements = #{count => 1},
     Metadata = #{client => Client},
-    telemetry:execute([shackle, replies], Measurements, Metadata).
+    shackle_hooks:event([shackle, replies], Measurements, Metadata).
 
 -spec reply(shackle:client(), term(), term(), non_neg_integer()) -> ok.
 reply(Client, Request, Response, Duration) ->
     Measurements = #{duration => Duration},
     Metadata = #{client => Client, request => Request, response => Response},
-    telemetry:execute([shackle, reply], Measurements, Metadata).
+    shackle_hooks:event([shackle, reply], Measurements, Metadata).
 
 -spec send(shackle:client(), non_neg_integer()) -> ok.
 send(Client, NBytes) ->
     Measurements = #{count => 1, bytes => NBytes},
     Metadata = #{client => Client},
-    telemetry:execute([shackle, send], Measurements, Metadata).
+    shackle_hooks:event([shackle, send], Measurements, Metadata).
 
 -spec timeout(shackle:client(), term()) -> ok.
 timeout(Client, Request) ->
     Measurements = #{count => 1},
     Metadata = #{client => Client, request => Request},
-    telemetry:execute([shackle, timeout], Measurements, Metadata).
+    shackle_hooks:event([shackle, timeout], Measurements, Metadata).

--- a/src/shackle_telemetry.erl
+++ b/src/shackle_telemetry.erl
@@ -14,9 +14,9 @@
     not_found/1,
     recv/2,
     replies/1,
-    reply/2,
+    reply/3,
     send/2,
-    timeout/1
+    timeout/2
 ]).
 
 -spec backlog_full(shackle:client()) -> ok.
@@ -79,10 +79,10 @@ replies(Client) ->
     Metadata = #{client => Client},
     telemetry:execute([shackle, replies], Measurements, Metadata).
 
--spec reply(shackle:client(), non_neg_integer()) -> ok.
-reply(Client, Microseconds) ->
+-spec reply(shackle:client(), term(), non_neg_integer()) -> ok.
+reply(Client, Request, Microseconds) ->
     Measurements = #{duration => Microseconds},
-    Metadata = #{client => Client},
+    Metadata = #{client => Client, request => Request},
     telemetry:execute([shackle, reply], Measurements, Metadata).
 
 -spec send(shackle:client(), non_neg_integer()) -> ok.
@@ -91,8 +91,8 @@ send(Client, NBytes) ->
     Metadata = #{client => Client},
     telemetry:execute([shackle, send], Measurements, Metadata).
 
--spec timeout(shackle:client()) -> ok.
-timeout(Client) ->
+-spec timeout(shackle:client(), term()) -> ok.
+timeout(Client, Request) ->
     Measurements = #{count => 1},
-    Metadata = #{client => Client},
+    Metadata = #{client => Client, request => Request},
     telemetry:execute([shackle, timeout], Measurements, Metadata).

--- a/src/shackle_telemetry.erl
+++ b/src/shackle_telemetry.erl
@@ -27,8 +27,8 @@ backlog_full(Client) ->
     telemetry:execute([shackle, backlog_full], Measurements, Metadata).
 
 -spec connected(shackle:client(), shackle_pool:name(), non_neg_integer()) -> ok.
-connected(Client, PoolName, Microseconds) ->
-    Measurements = #{count => 1, duration => Microseconds},
+connected(Client, PoolName, Duration) ->
+    Measurements = #{count => 1, duration => Duration},
     Metadata = #{client => Client, pool_name => PoolName},
     telemetry:execute([shackle, connected], Measurements, Metadata).
 
@@ -69,8 +69,8 @@ not_found(Client) ->
     telemetry:execute([shackle, not_found], Measurements, Metadata).
 
 -spec queued_time(shackle:client(), non_neg_integer()) -> ok.
-queued_time(Client, Microseconds) ->
-    Measurements = #{duration => Microseconds},
+queued_time(Client, Duration) ->
+    Measurements = #{duration => Duration},
     Metadata = #{client => Client},
     telemetry:execute([shackle, queued_time], Measurements, Metadata).
 
@@ -87,8 +87,8 @@ replies(Client) ->
     telemetry:execute([shackle, replies], Measurements, Metadata).
 
 -spec reply(shackle:client(), term(), term(), non_neg_integer()) -> ok.
-reply(Client, Request, Response, Microseconds) ->
-    Measurements = #{duration => Microseconds},
+reply(Client, Request, Response, Duration) ->
+    Measurements = #{duration => Duration},
     Metadata = #{client => Client, request => Request, response => Response},
     telemetry:execute([shackle, reply], Measurements, Metadata).
 

--- a/src/shackle_telemetry.erl
+++ b/src/shackle_telemetry.erl
@@ -5,6 +5,7 @@
 
 -export([
     backlog_full/1,
+    connected/3,
     connection_error/3,
     disabled/1,
     found/1,
@@ -23,6 +24,12 @@ backlog_full(Client) ->
     Measurements = #{count => 1},
     Metadata = #{client => Client},
     telemetry:execute([shackle, backlog_full], Measurements, Metadata).
+
+-spec connected(shackle:client(), shackle_pool:name(), non_neg_integer()) -> ok.
+connected(Client, PoolName, Microseconds) ->
+    Measurements = #{count => 1, duration => Microseconds},
+    Metadata = #{client => Client, pool_name => PoolName},
+    telemetry:execute([shackle, connected], Measurements, Metadata).
 
 -spec connection_error(shackle:client(), shackle_pool:name(), any()) -> ok.
 connection_error(Client, PoolName, Reason) ->

--- a/src/shackle_telemetry.erl
+++ b/src/shackle_telemetry.erl
@@ -12,6 +12,7 @@
     handle_timeout/1,
     no_server/1,
     not_found/1,
+    queued_time/2,
     recv/2,
     replies/1,
     reply/4,
@@ -66,6 +67,12 @@ not_found(Client) ->
     Measurements = #{count => 1},
     Metadata = #{client => Client},
     telemetry:execute([shackle, not_found], Measurements, Metadata).
+
+-spec queued_time(shackle:client(), non_neg_integer()) -> ok.
+queued_time(Client, Microseconds) ->
+    Measurements = #{duration => Microseconds},
+    Metadata = #{client => Client},
+    telemetry:execute([shackle, queued_time], Measurements, Metadata).
 
 -spec recv(shackle:client(), non_neg_integer()) -> ok.
 recv(Client, NBytes) ->

--- a/src/shackle_telemetry.erl
+++ b/src/shackle_telemetry.erl
@@ -14,7 +14,7 @@
     not_found/1,
     recv/2,
     replies/1,
-    reply/3,
+    reply/4,
     send/2,
     timeout/2
 ]).
@@ -79,10 +79,10 @@ replies(Client) ->
     Metadata = #{client => Client},
     telemetry:execute([shackle, replies], Measurements, Metadata).
 
--spec reply(shackle:client(), term(), non_neg_integer()) -> ok.
-reply(Client, Request, Microseconds) ->
+-spec reply(shackle:client(), term(), term(), non_neg_integer()) -> ok.
+reply(Client, Request, Response, Microseconds) ->
     Measurements = #{duration => Microseconds},
-    Metadata = #{client => Client, request => Request},
+    Metadata = #{client => Client, request => Request, response => Response},
     telemetry:execute([shackle, reply], Measurements, Metadata).
 
 -spec send(shackle:client(), non_neg_integer()) -> ok.

--- a/src/shackle_telemetry.erl
+++ b/src/shackle_telemetry.erl
@@ -5,6 +5,7 @@
 
 -export([
     backlog_full/1,
+    connection_error/3,
     disabled/1,
     found/1,
     handle_timeout/1,
@@ -22,6 +23,12 @@ backlog_full(Client) ->
     Measurements = #{count => 1},
     Metadata = #{client => Client},
     telemetry:execute([shackle, backlog_full], Measurements, Metadata).
+
+-spec connection_error(shackle:client(), shackle_pool:name(), any()) -> ok.
+connection_error(Client, PoolName, Reason) ->
+    Measurements = #{count => 1},
+    Metadata = #{client => Client, pool_name => PoolName, reason => Reason},
+    telemetry:execute([shackle, connection_error], Measurements, Metadata).
 
 -spec disabled(shackle:client()) -> ok.
 disabled(Client) ->


### PR DESCRIPTION
A couple of changes for your consideration:

1. Storing `Request` values (understood by implementors of `shackle_client`) in `shackle_queue`, and passing them to `shackle_telemetry:reply/4` and `shackle_telemetry:timeout/2`. I added this to get the HTTP status code and URL path from `buoy`.
2. Adding `shackle_telemetry:connection_error/2` and `shackle_telemetry:queued_time/2`.
3. Using `erlang:monotonic_time/{0,1}` to measure elapsed time, instead of `os:timestamp/0` and `timer:now_diff/2`. This is specifically called out in the [Time and Time Correction in Erlang](url), though it mentions `erlang:timestamp/0`. It does, however, recommend using `erlang:monotonic_time/0` and subtraction to measure elapsed time between events.

I got rid of a couple of `?WARN` invocations because they can be pretty spammy. I'm not sure what the best approach is to handling these log messages, or whether they can be adequately replaced with metrics. I'd be happy to add them back if you want.