### PR TITLE
Bump version to 0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.7.3
+
+### Changed
+
+- Upgrade foil to 0.1.6 and knot to 0.1.2.
+- Remove bench and profile tooling.
+
 ## 0.7.2
 
 ### Added

--- a/src/shackle.app.src
+++ b/src/shackle.app.src
@@ -6,5 +6,5 @@
   {links, [{"GitHub", "https://github.com/lpgauth/shackle"}]},
   {mod, {shackle_app, []}},
   {registered, []},
-  {vsn, "0.7.2"}
+  {vsn, "0.7.3"}
 ]}.


### PR DESCRIPTION
## Summary
- Bump version to 0.7.3 in shackle.app.src
- Add 0.7.3 CHANGELOG entry (foil 0.1.6 + knot 0.1.2 upgrades, bench/profile tooling removal)

Note: this commit was pushed to #137 but the PR merged before it landed, so it's re-submitted here.